### PR TITLE
release 1.6.1: event mode, USB browse-in-place, overlay swap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,10 @@ wins on load. Caches (Track Atlas snapshot) stay outside the file.
   expose `TelemetryStore::loading` so every session-library surface can retain
   its current data and show progress while a replacement snapshot is built.
 - A local file is its own parser path. `openIndex()` reads only what the
-  sidebar needs, so there is no session-index cache and no conversion step;
-  nothing is ever written beside the source or derived from it on disk.
+  sidebar needs. A compact metadata cache lives under
+  `$XDG_CACHE_HOME/omatrack/index/{generation}/`, keyed by POSIX
+  `(dev, ino, size, mtime)` and `omatrack::converterGeneration()`. Failures
+  are not stored. Nothing is written beside the source recording.
   Only remote recordings get a `.telemetry` (below).
 - Dispatch formats through the Rust parser workspace.
 - Infer inexpensive metadata from filenames/folders before parsing samples.
@@ -175,11 +177,13 @@ wins on load. Caches (Track Atlas snapshot) stay outside the file.
   second parallel list. `~/Documents/Telemetry` (resolved through the platform
   Documents location, so Windows OneDrive redirection is honored) is the only
   location on a fresh install and is created if missing.
-- Ready USB-backed volumes are detected automatically and scanned off the UI
-  thread. A mount is a transient `USB — …` library section only when that scan
-  finds a supported telemetry or video file. It is never added to `locations`
-  or otherwise persisted, and detaching it removes the section on the next
-  mount check.
+- Ready USB-backed volumes are detected by wiring `mountedUsbVolumes()` to a
+  `QStorageInfo` poll plus `QFileSystemWatcher` on `/run/media/$USER` and
+  `/media`, then scanned off the UI thread (`AsyncJob`). A mount is a transient
+  `USB — …` library section only when that scan finds a supported telemetry or
+  video file. It is never added to `locations`. Copy is a separate overlay in
+  the video slot, using `usb.dest` / `usb.format` / optional `usb.rename_script`
+  in `omatrack.yml`. Source files stay immutable.
 - Remote connections are synchronized into a local discovery cache containing
   zero-byte source stubs and ETag metadata; source bytes are never retained as
   a second telemetry cache. Before parsing a remote file, lookup uses its ETag
@@ -616,6 +620,9 @@ Warnings (`-Wall -Wextra`) come from the `omatrack_warnings` interface target.
   invent a parallel JSON/Motec sidecar or re-derive it in QML.
 - New cross-format channel or unit rule: `TelemetryEngine` and `UnifiedLap`.
 - New lap/corner comparison metric: C++ analysis in the store/core, exposed as compact view data. A new corner *check* is a `CornerAnalyzer` in `src/core/CornerAnalysis.cpp` — never an inline `if` in the store and never a string built in QML.
+- USB copy rename: optional Lua 5.4 + sol2 in `src/app` (`LuaRename.*`), never
+  in `omatrack_core`. `rename(ctx)` returns a relative path that is jailed
+  under the destination. Example scripts belong in preferences, not plugins.
 - New persistent user preference: a typed field on `PreferencesStore` (or
   `AppUpdater` for update state), loaded in `loadPreferences()` and written by
   the debounced `schedulePreferencesSave()` path into `omatrack.yml`; never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable user-facing changes are documented here.
 
+## 1.6.1 — 2026-08-30
+
+- Header update control shows download percent and bytes next to the icon.
+- Sidebar, channels, laps, and other list models refresh with insert/remove
+  instead of resetting, so scroll position and selection survive a rescan or
+  filter change.
+- Event mode filters the library to one track and day, with a first-class
+  session name (`c1`, `c2`, …) shown in the toolbar and passed to USB copy
+  and Lua rename. Stored in `omatrack.yml`.
+- USB volumes are detected (`mountedUsbVolumes()` is wired) and shown as a
+  transient `USB — …` sidebar section. Nothing is copied until the Copy
+  overlay in the video slot is used. Destination and `{track}/{date}/{session}/{original}`
+  live in `omatrack.yml`.
+- Optional Lua 5.4 rename sandbox (no `io`/`os`/`load`/`setmetatable`,
+  instruction hook plus memory cap) returns a jailed relative path only.
+- Location and USB mount watches debounce into the existing scan job.
+- Sidebar `openIndex` cache lives under `$XDG_CACHE_HOME` and is keyed by
+  POSIX identity plus `converterGeneration()`. Failures are not stored.
+  Nothing is written beside the source recording.
+- Fullscreen overlay reference traces take color, dash/dot, and a white
+  similar-thickness preset from preferences.
+- `X` swaps primary and reference analysis roles (no-op without a reference)
+  and is offered on the filmstrip label. Text fields keep `X`.
+
 ## 1.6.0 — 2026-08-29
 
 - Updated the telemetry readers to the tested `motorsport-telemetry-rs`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(omatrack VERSION 1.6.0 LANGUAGES CXX)
+project(omatrack VERSION 1.6.1 LANGUAGES CXX)
 if(WIN32)
   # Windows release layout: the app ships as a flat zip, so executables and
   # their load-time DLLs install at the prefix root and every non-binary
@@ -96,6 +96,7 @@ if(OMATRACK_STATIC_GNU_RUNTIME)
     -static-libgcc -static-libstdc++)
 endif()
 
+include(cmake/LuaSandbox.cmake)
 add_subdirectory(third_party)
 add_subdirectory(src/core)
 add_subdirectory(cli)

--- a/cmake/LuaSandbox.cmake
+++ b/cmake/LuaSandbox.cmake
@@ -23,8 +23,9 @@ FetchContent_Declare(
   DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
 FetchContent_Declare(
   sol2
+  # d805d02: optional<T&>::emplace fix for GCC 15 / Clang 19
   GIT_REPOSITORY https://github.com/ThePhD/sol2.git
-  GIT_TAG v3.3.1)
+  GIT_TAG d805d027e0a0a7222e936926139f06e23828ce9f)
 FetchContent_GetProperties(lua_src)
 if(NOT lua_src_POPULATED)
   FetchContent_Populate(lua_src)

--- a/cmake/LuaSandbox.cmake
+++ b/cmake/LuaSandbox.cmake
@@ -1,0 +1,80 @@
+if(TARGET lua_sandbox)
+  return()
+endif()
+
+enable_language(C)
+
+# Lua 5.4 + sol2 for the USB rename sandbox in src/app.
+#
+# Lua is compiled without io/os/package/debug so those libraries cannot be
+# opened even if a script asked. sol2 is header-only and used only here.
+# Neither upstream archive is added as a CMake subproject: lua has no
+# CMakeLists, and sol2's would try to find a system Lua.
+include(FetchContent)
+if(POLICY CMP0169)
+  cmake_policy(SET CMP0169 OLD)
+endif()
+
+set(LUA_VERSION 5.4.7)
+FetchContent_Declare(
+  lua_src
+  URL https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz
+  URL_HASH SHA256=9fbf5e28ef86c69858f6d3d34eccc32e911c1a28b4120ff3e84aaa70cfbf1e30
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+FetchContent_Declare(
+  sol2
+  GIT_REPOSITORY https://github.com/ThePhD/sol2.git
+  GIT_TAG v3.3.1)
+FetchContent_GetProperties(lua_src)
+if(NOT lua_src_POPULATED)
+  FetchContent_Populate(lua_src)
+endif()
+FetchContent_GetProperties(sol2)
+if(NOT sol2_POPULATED)
+  FetchContent_Populate(sol2)
+endif()
+
+set(LUA_CORE
+  ${lua_src_SOURCE_DIR}/src/lapi.c
+  ${lua_src_SOURCE_DIR}/src/lcode.c
+  ${lua_src_SOURCE_DIR}/src/lctype.c
+  ${lua_src_SOURCE_DIR}/src/ldebug.c
+  ${lua_src_SOURCE_DIR}/src/ldo.c
+  ${lua_src_SOURCE_DIR}/src/ldump.c
+  ${lua_src_SOURCE_DIR}/src/lfunc.c
+  ${lua_src_SOURCE_DIR}/src/lgc.c
+  ${lua_src_SOURCE_DIR}/src/llex.c
+  ${lua_src_SOURCE_DIR}/src/lmem.c
+  ${lua_src_SOURCE_DIR}/src/lobject.c
+  ${lua_src_SOURCE_DIR}/src/lopcodes.c
+  ${lua_src_SOURCE_DIR}/src/lparser.c
+  ${lua_src_SOURCE_DIR}/src/lstate.c
+  ${lua_src_SOURCE_DIR}/src/lstring.c
+  ${lua_src_SOURCE_DIR}/src/ltable.c
+  ${lua_src_SOURCE_DIR}/src/ltm.c
+  ${lua_src_SOURCE_DIR}/src/lundump.c
+  ${lua_src_SOURCE_DIR}/src/lvm.c
+  ${lua_src_SOURCE_DIR}/src/lzio.c)
+set(LUA_LIBS
+  ${lua_src_SOURCE_DIR}/src/lauxlib.c
+  ${lua_src_SOURCE_DIR}/src/lbaselib.c
+  ${lua_src_SOURCE_DIR}/src/lmathlib.c
+  ${lua_src_SOURCE_DIR}/src/lstrlib.c
+  ${lua_src_SOURCE_DIR}/src/ltablib.c
+  ${lua_src_SOURCE_DIR}/src/lutf8lib.c)
+
+add_library(lua_sandbox STATIC ${LUA_CORE} ${LUA_LIBS})
+set_target_properties(lua_sandbox PROPERTIES
+  C_STANDARD 99
+  POSITION_INDEPENDENT_CODE ON)
+target_include_directories(lua_sandbox PUBLIC ${lua_src_SOURCE_DIR}/src)
+# The interpreter, compiler, io, os, package, coroutine, and debug libraries
+# stay out of this target on purpose.
+if(NOT WIN32)
+  target_compile_definitions(lua_sandbox PRIVATE LUA_USE_POSIX)
+  target_link_libraries(lua_sandbox PUBLIC m)
+endif()
+
+add_library(sol2_headers INTERFACE)
+target_include_directories(sol2_headers INTERFACE ${sol2_SOURCE_DIR}/include)
+target_link_libraries(sol2_headers INTERFACE lua_sandbox)

--- a/src/app/AppHeader.qml
+++ b/src/app/AppHeader.qml
@@ -206,7 +206,7 @@ ToolBar {
             id: updateCluster
 
             spacing: 4
-            visible: Updater.supported && Updater.enabled && Updater.available
+            visible: Updater.supported && Updater.enabled && (Updater.available || Updater.busy)
 
             CompactToolButton {
                 id: updateButton
@@ -244,12 +244,19 @@ ToolBar {
 
                 onClicked: Updater.snooze()
             }
+            ProgressBar {
+                Layout.preferredWidth: 88
+                from: 0
+                to: 1
+                value: Updater.progress
+                visible: Updater.busy
+            }
             Label {
                 color: Style.mutedTextColor
                 elide: Text.ElideRight
                 font.family: Style.monoFontFamily
                 font.pixelSize: 10
-                text: Updater.status
+                text: Updater.downloadLabel !== "" ? Updater.downloadLabel : Updater.status
                 visible: Updater.busy && appBar.width >= 780
             }
         }

--- a/src/app/AppUpdater.cpp
+++ b/src/app/AppUpdater.cpp
@@ -833,6 +833,8 @@ void AppUpdater::install() {
                     guard.data(),  // null-safe context; the functor re-checks
                     [guard, received, total, value]() {
                         if (!guard) return;
+                        guard->downloadBytes_ = received;
+                        guard->downloadTotal_ = total;
                         guard->setProgress(value);
                         if (total > 0)
                             guard->setPhase(
@@ -919,9 +921,22 @@ void AppUpdater::setPhase(Phase phase, const QString& status,
 }
 
 void AppUpdater::setProgress(double progress) {
-    if (qFuzzyCompare(progress_, progress)) return;
+    if (qFuzzyCompare(progress_, progress) && progress_ == progress) {
+        emit progressChanged();
+        return;
+    }
     progress_ = progress;
     emit progressChanged();
+}
+
+QString AppUpdater::downloadLabel() const {
+    if (downloadTotal_ > 0)
+        return QStringLiteral("%1% · %2 / %3")
+            .arg(int(progress_ * 100.0 + 0.5))
+            .arg(omatrack::formatBytes(downloadBytes_),
+                 omatrack::formatBytes(downloadTotal_));
+    if (downloadBytes_ > 0) return omatrack::formatBytes(downloadBytes_);
+    return {};
 }
 
 void AppUpdater::emitVisibility() { emit bannerVisibleChanged(); }

--- a/src/app/AppUpdater.h
+++ b/src/app/AppUpdater.h
@@ -35,6 +35,9 @@ class AppUpdater : public QObject {
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
     Q_PROPERTY(QString error READ error NOTIFY statusChanged)
     Q_PROPERTY(double progress READ progress NOTIFY progressChanged)
+    Q_PROPERTY(qint64 downloadBytes READ downloadBytes NOTIFY progressChanged)
+    Q_PROPERTY(qint64 downloadTotal READ downloadTotal NOTIFY progressChanged)
+    Q_PROPERTY(QString downloadLabel READ downloadLabel NOTIFY progressChanged)
     Q_PROPERTY(bool associationPrompt READ associationPrompt NOTIFY
                    associationPromptChanged)
     Q_PROPERTY(int associationCount READ associationCount NOTIFY
@@ -54,6 +57,9 @@ public:
     QString status() const { return status_; }
     QString error() const { return error_; }
     double progress() const { return progress_; }
+    qint64 downloadBytes() const { return downloadBytes_; }
+    qint64 downloadTotal() const { return downloadTotal_; }
+    QString downloadLabel() const;
     bool associationPrompt() const { return associationPrompt_; }
     int associationCount() const;
 
@@ -116,6 +122,8 @@ private:
     QString snoozeVersion_;
     QString lastCheck_;
     double progress_ = 0.0;
+    qint64 downloadBytes_ = 0;
+    qint64 downloadTotal_ = 0;
     quint64 generation_ = 0;
     omatrack::GithubRelease latest_;
     std::shared_ptr<std::atomic<bool>> cancel_;

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -83,6 +83,9 @@ qt_add_qml_module(omatrack
     VideoMetadataDialog.qml
     VideoTelemetryOverlay.qml
     VideoDeltaBar.qml
+    UsbCopyOverlay.qml
+    PreferencesEventPage.qml
+    PreferencesOverlayPage.qml
   SOURCES
     AsyncJob.h
     FilterChange.h
@@ -109,6 +112,10 @@ qt_add_qml_module(omatrack
     TraceSceneBuilder.h TraceSceneBuilder.cpp
     TraceTextCache.h TraceTextCache.cpp
     UsbMedia.h UsbMedia.cpp
+    PathJail.h PathJail.cpp
+    IndexCache.h IndexCache.cpp
+    LuaRename.h LuaRename.cpp
+    ModelDiff.h
     VerboseLog.h VerboseLog.cpp
     SingleInstance.h SingleInstance.cpp
     TraceSnapshot.h
@@ -143,6 +150,8 @@ qt_add_resources(omatrack "omatrack_branding"
     ${CMAKE_SOURCE_DIR}/assets/omatrack.ico)
 
 target_link_libraries(omatrack PRIVATE
+  lua_sandbox
+  sol2_headers
   omatrack_core
   omatrack_headless
   omatrack_portable_runtime

--- a/src/app/ChannelsWindow.qml
+++ b/src/app/ChannelsWindow.qml
@@ -161,7 +161,9 @@ ApplicationWindow {
             Layout.fillHeight: true
             Layout.fillWidth: true
             clip: true
+            highlightFollowsCurrentItem: false
             model: channelFilter
+            reuseItems: true
             spacing: 2
 
             delegate: Rectangle {

--- a/src/app/FileBrowserPane.qml
+++ b/src/app/FileBrowserPane.qml
@@ -43,10 +43,6 @@ Pane {
         else
             filterModel.selectedYears = current.concat([name]);
     }
-    function updateFileMetadata(path: string, details: var): void {
-    // The C++ model handles metadata updates via the store's
-    // sidebarMetadataChanged signal; nothing to do here.
-    }
 
     padding: 0
 

--- a/src/app/FileBrowserPane.qml
+++ b/src/app/FileBrowserPane.qml
@@ -44,8 +44,8 @@ Pane {
             filterModel.selectedYears = current.concat([name]);
     }
     function updateFileMetadata(path: string, details: var): void {
-        // The C++ model handles metadata updates via the store's
-        // sidebarMetadataChanged signal; nothing to do here.
+    // The C++ model handles metadata updates via the store's
+    // sidebarMetadataChanged signal; nothing to do here.
     }
 
     padding: 0
@@ -54,15 +54,31 @@ Pane {
         color: Style.darkBackgroundColor
     }
 
+    Component.onCompleted: {
+        if (Store.eventMode) {
+            if (Store.eventTrack !== "")
+                filterModel.selectedTrack = Store.eventTrack;
+            filterModel.selectedDay = Store.eventDate;
+        }
+    }
+
     LibraryFilterModel {
         id: filterModel
 
         sourceModel: Store.library
     }
     Connections {
+        function onEventChanged(): void {
+            if (Store.eventMode) {
+                if (Store.eventTrack !== "")
+                    filterModel.selectedTrack = Store.eventTrack;
+                filterModel.selectedDay = Store.eventDate;
+            } else {
+                filterModel.selectedDay = "";
+            }
+        }
         function onSelectionChanged(): void {
-            if (filterModel.revealSession(Store.primarySessionKey))
-                filterModel.invalidate();
+            filterModel.revealSession(Store.primarySessionKey);
         }
 
         target: Store
@@ -299,17 +315,60 @@ Pane {
                 }
             }
         }
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 28
+            color: Style.surfaceColor
+            visible: Store.usbPresent
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: 8
+                anchors.rightMargin: 4
+                spacing: 6
+
+                Label {
+                    Layout.fillWidth: true
+                    color: Style.accentColor
+                    elide: Text.ElideRight
+                    font.family: Style.monoFontFamily
+                    font.pixelSize: 10
+                    text: Store.usbLabel
+                }
+                CompactButton {
+                    text: "Copy…"
+
+                    onClicked: Store.showUsbCopy()
+                }
+            }
+        }
         Item {
             Layout.fillHeight: true
             Layout.fillWidth: true
 
+            Timer {
+                id: restoreScrollTimer
+
+                property int savedFirst: -1
+                property real savedY: 0
+
+                interval: 0
+
+                onTriggered: {
+                    if (restoreScrollTimer.savedFirst >= 0)
+                        tree.positionViewAtIndex(restoreScrollTimer.savedFirst, ListView.Beginning);
+                    tree.contentY = restoreScrollTimer.savedY;
+                }
+            }
             ListView {
                 id: tree
 
                 anchors.fill: parent
                 boundsBehavior: Flickable.StopAtBounds
                 clip: true
+                highlightFollowsCurrentItem: false
                 model: filterModel
+                reuseItems: true
 
                 ScrollBar.vertical: ThinScrollBar {
                 }
@@ -347,6 +406,32 @@ Pane {
                     onSetActiveRequested: key => browser.setActiveRequested(key)
                     onSetReferenceRequested: key => browser.setReferenceRequested(key)
                     onToggleNodeRequested: (role, path) => filterModel.toggleNode(role, path)
+                }
+
+                Connections {
+                    function onLayoutAboutToBeChanged(): void {
+                        restoreScrollTimer.savedY = tree.contentY;
+                        restoreScrollTimer.savedFirst = tree.indexAt(1, tree.contentY + 1);
+                    }
+                    function onLayoutChanged(): void {
+                        restoreScrollTimer.restart();
+                    }
+                    function onRowsAboutToBeInserted(): void {
+                        restoreScrollTimer.savedY = tree.contentY;
+                        restoreScrollTimer.savedFirst = tree.indexAt(1, tree.contentY + 1);
+                    }
+                    function onRowsAboutToBeRemoved(): void {
+                        restoreScrollTimer.savedY = tree.contentY;
+                        restoreScrollTimer.savedFirst = tree.indexAt(1, tree.contentY + 1);
+                    }
+                    function onRowsInserted(): void {
+                        restoreScrollTimer.restart();
+                    }
+                    function onRowsRemoved(): void {
+                        restoreScrollTimer.restart();
+                    }
+
+                    target: filterModel
                 }
             }
             Column {

--- a/src/app/IndexCache.cpp
+++ b/src/app/IndexCache.cpp
@@ -1,0 +1,143 @@
+#include "IndexCache.h"
+
+#include "core/TelemetryEngine.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QSaveFile>
+#include <QStandardPaths>
+
+#ifdef Q_OS_UNIX
+#include <sys/stat.h>
+#endif
+#ifdef Q_OS_WIN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+namespace omatrack {
+namespace {
+
+QString cacheRoot() {
+    const QString xdg = QString::fromLocal8Bit(qgetenv("XDG_CACHE_HOME"));
+    if (!xdg.trimmed().isEmpty())
+        return QDir(xdg).filePath(QStringLiteral("omatrack"));
+    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+}
+
+QString generationKey() {
+    return QString::fromStdString(omatrack::converterGeneration());
+}
+
+}  // namespace
+
+FileIdentity fileIdentity(const QString& path) {
+    FileIdentity identity;
+    identity.generation = generationKey();
+    if (path.isEmpty()) return identity;
+#ifdef Q_OS_UNIX
+    struct stat st{};
+    if (stat(QFile::encodeName(path).constData(), &st) != 0) return identity;
+    identity.device = static_cast<quint64>(st.st_dev);
+    identity.inode = static_cast<quint64>(st.st_ino);
+    identity.size = static_cast<qint64>(st.st_size);
+#if defined(__APPLE__)
+    identity.mtimeNs =
+        static_cast<qint64>(st.st_mtimespec.tv_sec) * 1000000000LL +
+        static_cast<qint64>(st.st_mtimespec.tv_nsec);
+#else
+    identity.mtimeNs = static_cast<qint64>(st.st_mtim.tv_sec) * 1000000000LL +
+                       static_cast<qint64>(st.st_mtim.tv_nsec);
+#endif
+    identity.valid = identity.inode != 0 || identity.size >= 0;
+    return identity;
+#elif defined(Q_OS_WIN)
+    const QString native = QDir::toNativeSeparators(path);
+    HANDLE handle =
+        CreateFileW(reinterpret_cast<LPCWSTR>(native.utf16()), GENERIC_READ,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (handle == INVALID_HANDLE_VALUE) return identity;
+    BY_HANDLE_FILE_INFORMATION info{};
+    const BOOL ok = GetFileInformationByHandle(handle, &info);
+    CloseHandle(handle);
+    if (!ok) return identity;
+    identity.device = info.dwVolumeSerialNumber;
+    identity.inode =
+        (static_cast<quint64>(info.nFileIndexHigh) << 32) | info.nFileIndexLow;
+    identity.size =
+        (static_cast<qint64>(info.nFileSizeHigh) << 32) | info.nFileSizeLow;
+    ULARGE_INTEGER mtime;
+    mtime.LowPart = info.ftLastWriteTime.dwLowDateTime;
+    mtime.HighPart = info.ftLastWriteTime.dwHighDateTime;
+    identity.mtimeNs = static_cast<qint64>(mtime.QuadPart);
+    identity.valid = true;
+    return identity;
+#else
+    const QFileInfo info(path);
+    if (!info.exists()) return identity;
+    identity.size = info.size();
+    identity.mtimeNs = info.lastModified().toMSecsSinceEpoch() * 1000000LL;
+    identity.valid = true;
+    return identity;
+#endif
+}
+
+QString indexCachePath(const FileIdentity& identity) {
+    if (!identity.valid || identity.generation.isEmpty()) return {};
+    const QString dir =
+        QDir(cacheRoot())
+            .filePath(QStringLiteral("index/") + identity.generation);
+    return QDir(dir).filePath(QStringLiteral("%1-%2-%3-%4.json")
+                                  .arg(identity.device)
+                                  .arg(identity.inode)
+                                  .arg(identity.size)
+                                  .arg(identity.mtimeNs));
+}
+
+QJsonObject loadIndexCache(const QString& path) {
+    const FileIdentity identity = fileIdentity(path);
+    const QString cachePath = indexCachePath(identity);
+    if (cachePath.isEmpty()) return {};
+    QFile file(cachePath);
+    if (!file.open(QIODevice::ReadOnly)) return {};
+    QJsonParseError error;
+    const QJsonDocument document =
+        QJsonDocument::fromJson(file.readAll(), &error);
+    if (error.error != QJsonParseError::NoError || !document.isObject())
+        return {};
+    QJsonObject object = document.object();
+    if (object.value(QStringLiteral("converterGeneration")).toString() !=
+        identity.generation)
+        return {};
+    const QJsonObject metadata =
+        object.value(QStringLiteral("metadata")).toObject();
+    return metadata;
+}
+
+bool storeIndexCache(const QString& path, const QJsonObject& metadata) {
+    if (metadata.isEmpty()) return false;
+    const FileIdentity identity = fileIdentity(path);
+    const QString cachePath = indexCachePath(identity);
+    if (cachePath.isEmpty()) return false;
+    QDir().mkpath(QFileInfo(cachePath).absolutePath());
+    QJsonObject object{
+        {QStringLiteral("converterGeneration"), identity.generation},
+        {QStringLiteral("device"), QString::number(identity.device)},
+        {QStringLiteral("inode"), QString::number(identity.inode)},
+        {QStringLiteral("size"), identity.size},
+        {QStringLiteral("mtimeNs"), identity.mtimeNs},
+        {QStringLiteral("metadata"), metadata},
+    };
+    QSaveFile file(cachePath);
+    if (!file.open(QIODevice::WriteOnly)) return false;
+    file.write(QJsonDocument(object).toJson(QJsonDocument::Compact));
+    return file.commit();
+}
+
+}  // namespace omatrack

--- a/src/app/IndexCache.cpp
+++ b/src/app/IndexCache.cpp
@@ -41,7 +41,7 @@ FileIdentity fileIdentity(const QString& path) {
     identity.generation = generationKey();
     if (path.isEmpty()) return identity;
 #ifdef Q_OS_UNIX
-    struct stat st{};
+    struct stat st = {};
     if (stat(QFile::encodeName(path).constData(), &st) != 0) return identity;
     identity.device = static_cast<quint64>(st.st_dev);
     identity.inode = static_cast<quint64>(st.st_ino);

--- a/src/app/IndexCache.h
+++ b/src/app/IndexCache.h
@@ -1,0 +1,37 @@
+// Sidebar openIndex cache under XDG_CACHE_HOME.
+//
+// Keyed by POSIX (dev, ino, size, mtime) plus converterGeneration() so a
+// decoder pin bump invalidates every entry. Failures are never stored.
+// Nothing is written beside the source recording.
+#pragma once
+
+#include <QJsonObject>
+#include <QtGlobal>
+#include <QString>
+
+namespace omatrack {
+
+struct FileIdentity {
+    quint64 device = 0;
+    quint64 inode = 0;
+    qint64 size = -1;
+    qint64 mtimeNs = 0;
+    QString generation;
+    bool valid = false;
+};
+
+/// Identity of `path` plus `omatrack::converterGeneration()`. Invalid when
+/// the file cannot be stated.
+FileIdentity fileIdentity(const QString& path);
+
+/// `$XDG_CACHE_HOME/omatrack/index/{generation}/…`. Empty when identity is
+/// invalid.
+QString indexCachePath(const FileIdentity& identity);
+
+/// Stored JSON, or an empty object on miss / malformed / generation mismatch.
+QJsonObject loadIndexCache(const QString& path);
+
+/// Write a successful openIndex snapshot. No-op when identity is invalid.
+bool storeIndexCache(const QString& path, const QJsonObject& metadata);
+
+}  // namespace omatrack

--- a/src/app/LapFilmstrip.qml
+++ b/src/app/LapFilmstrip.qml
@@ -25,6 +25,16 @@ Rectangle {
     color: Style.traceBackgroundColor
     visible: filmstrip.sessions.length > 0
 
+    Menu {
+        id: swapReferenceMenu
+
+        MenuItem {
+            enabled: Store.comparing
+            text: "Swap with reference  X"
+
+            onTriggered: Store.swapPrimaryWithReference()
+        }
+    }
     Column {
         anchors.fill: parent
         anchors.margins: 6
@@ -59,6 +69,8 @@ Rectangle {
                     spacing: 5
 
                     DenseTwoLineRow {
+                        id: stripLabel
+
                         Layout.maximumWidth: 190
                         Layout.minimumWidth: 190
                         Layout.preferredWidth: 190
@@ -73,6 +85,13 @@ Rectangle {
                         titleFamily: Style.monoFontFamily
                         titleSize: 9
                         titleSpacing: 4
+
+                        MouseArea {
+                            acceptedButtons: Qt.RightButton
+                            anchors.fill: parent
+
+                            onClicked: swapReferenceMenu.popup()
+                        }
                     }
                     CompactToolButton {
                         Layout.preferredHeight: 24

--- a/src/app/LapFilmstrip.qml
+++ b/src/app/LapFilmstrip.qml
@@ -5,25 +5,22 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
-// Proportional lap filmstrip: one row per active/reference session, each row
-// a proportional bar of its laps with the best lap highlighted. Extracted
-// from Main.qml; the root passes the session strip array and receives
-// signals for pointer tooltips and the right-click lap menu.
+// Proportional lap filmstrip: one row per active/reference session. Laps fill
+// the lane by time, including Out/In/Frag. Left click selects the current lap
+// for that session; right click on a bar sets comparison. Label right-click
+// stays "Swap with reference  X".
 
 Rectangle {
     id: filmstrip
 
-    property var sessions: []
-
-    signal lapMenuRequested(string sessionKey, int lapId, real x, real y)
     signal pointerTooltipDismissed(string owner)
     signal pointerTooltipMoved(string owner, real x, real y)
     signal pointerTooltipRequested(string owner, string text, real x, real y)
 
     Layout.fillWidth: true
-    Layout.preferredHeight: visible ? filmstrip.sessions.length * 33 + 9 : 0
+    Layout.preferredHeight: visible ? Store.filmstripSessions.count * 33 + 9 : 0
     color: Style.traceBackgroundColor
-    visible: filmstrip.sessions.length > 0
+    visible: Store.filmstripSessions.count > 0
 
     Menu {
         id: swapReferenceMenu
@@ -41,23 +38,25 @@ Rectangle {
         spacing: 3
 
         Repeater {
-            model: filmstrip.sessions
+            model: Store.filmstripSessions
 
             delegate: Rectangle {
                 id: sessionStrip
 
-                readonly property var laps: sessionStrip.strip.reference ? Store.compareLaps : Store.primaryLaps
-                required property var modelData
+                required property string bestTime
+                required property string driverName
+                readonly property var laps: sessionStrip.reference ? Store.compareLaps : Store.primaryLaps
+                required property bool reference
                 property string selectedLapTime: {
-                    const key = strip.reference ? Store.compareSessionKey : Store.primarySessionKey;
-                    const idx = strip.reference ? Store.compareLapIndex : Store.primaryLapIndex;
-                    if (key === strip.sessionKey && idx >= 0)
+                    const key = sessionStrip.reference ? Store.compareSessionKey : Store.primarySessionKey;
+                    const idx = sessionStrip.reference ? Store.compareLapIndex : Store.primaryLapIndex;
+                    if (key === sessionStrip.sessionKey && idx >= 0)
                         return Store.lapTimeText(key, idx);
-                    return strip.bestTime;
+                    return sessionStrip.bestTime;
                 }
-                property var strip: modelData
+                required property string sessionKey
 
-                color: strip.reference ? Qt.tint(Style.surfaceColor, Qt.rgba(Style.orangeColor.r, Style.orangeColor.g, Style.orangeColor.b, 0.08)) : Style.surfaceColor
+                color: sessionStrip.reference ? Qt.tint(Style.surfaceColor, Qt.rgba(Style.orangeColor.r, Style.orangeColor.g, Style.orangeColor.b, 0.08)) : Style.surfaceColor
                 height: 30
                 radius: 4
                 width: parent.width
@@ -75,13 +74,13 @@ Rectangle {
                         Layout.minimumWidth: 190
                         Layout.preferredWidth: 190
                         detailVisible: false
-                        rightColor: sessionStrip.strip.reference ? Style.orangeColor : Style.accentColor
+                        rightColor: sessionStrip.reference ? Style.orangeColor : Style.accentColor
                         rightFamily: Style.monoFontFamily
                         rightSize: 9
                         rightValue: sessionStrip.selectedLapTime
-                        title: sessionStrip.strip.driverName !== "" && sessionStrip.strip.driverName !== "Unknown" ? sessionStrip.strip.driverName : "Unknown driver"
+                        title: sessionStrip.driverName !== "" && sessionStrip.driverName !== "Unknown" ? sessionStrip.driverName : "Unknown driver"
                         titleBold: true
-                        titleColor: sessionStrip.strip.reference ? Style.orangeColor : Style.accentColor
+                        titleColor: sessionStrip.reference ? Style.orangeColor : Style.accentColor
                         titleFamily: Style.monoFontFamily
                         titleSize: 9
                         titleSpacing: 4
@@ -97,9 +96,9 @@ Rectangle {
                         Layout.preferredHeight: 24
                         Layout.preferredWidth: 24
                         text: "×"
-                        tip: sessionStrip.strip.reference ? "Remove reference session" : "Clear active session"
+                        tip: sessionStrip.reference ? "Remove reference session" : "Clear active session"
 
-                        onClicked: sessionStrip.strip.reference ? Store.clearCompare() : Store.clearPrimary()
+                        onClicked: sessionStrip.reference ? Store.clearCompare() : Store.clearPrimary()
                     }
                     Item {
                         Layout.preferredWidth: 7
@@ -122,30 +121,30 @@ Rectangle {
                                 delegate: Rectangle {
                                     id: proportionalLap
 
-                                    readonly property bool confidenceLap: !sessionStrip.strip.reference && Store.traceConfidenceMode && Store.traceConfidenceIncludesLap(sessionStrip.strip.sessionKey, proportionalLap.lapId)
+                                    readonly property bool confidenceLap: !sessionStrip.reference && Store.traceConfidenceMode && Store.traceConfidenceIncludesLap(sessionStrip.sessionKey, proportionalLap.lapId)
                                     required property bool countsForBest
-                                    readonly property real flexibleLaneWidth: Math.max(0, proportionalLapLane.width - Math.max(0, sessionStrip.laps.rowCount - 1) * proportionalLapRow.spacing - (sessionStrip.laps.fixedLapCount === sessionStrip.laps.rowCount ? 0 : sessionStrip.laps.fixedLapCount * 30))
+                                    required property string hoverText
+                                    required property bool isComplete
                                     required property bool isFastest
                                     required property string label
                                     required property int lapId
-                                    readonly property bool pinIncomplete: !proportionalLap.countsForBest && sessionStrip.laps.fixedLapCount !== sessionStrip.laps.rowCount
-                                    property bool selectedLap: sessionStrip.strip.reference ? sessionStrip.strip.sessionKey === Store.compareSessionKey && proportionalLap.lapId === Store.compareLapIndex : sessionStrip.strip.sessionKey === Store.primarySessionKey && proportionalLap.lapId === Store.primaryLapIndex
+                                    property bool selectedLap: sessionStrip.reference ? sessionStrip.sessionKey === Store.compareSessionKey && proportionalLap.lapId === Store.compareLapIndex : sessionStrip.sessionKey === Store.primarySessionKey && proportionalLap.lapId === Store.primaryLapIndex
                                     required property int timeMs
                                     required property string timeText
-                                    readonly property string tooltipOwner: "lap:" + sessionStrip.strip.sessionKey + ":" + proportionalLap.lapId + ":" + sessionStrip.strip.reference
+                                    readonly property string tooltipOwner: "lap:" + sessionStrip.sessionKey + ":" + proportionalLap.lapId + ":" + sessionStrip.reference
 
                                     // Bound to the Row, not `parent`:
                                     // a delegate evaluates its
                                     // bindings before it is reparented,
                                     // so `parent` is null on creation.
                                     anchors.verticalCenter: proportionalLapRow.verticalCenter
-                                    border.color: sessionStrip.strip.reference ? Style.orangeColor : Style.accentColor
+                                    border.color: sessionStrip.reference ? Style.orangeColor : Style.accentColor
                                     border.width: proportionalLap.selectedLap || proportionalLap.confidenceLap ? 1 : 0
                                     color: proportionalLap.selectedLap ? Style.selectionColor : proportionalLap.confidenceLap ? Qt.tint(Style.traceBackgroundColor, Qt.rgba(Style.accentColor.r, Style.accentColor.g, Style.accentColor.b, 0.2)) : proportionalLapMouse.containsMouse ? Style.backgroundColor : Style.traceBackgroundColor
                                     height: proportionalLapRow.height - 8
-                                    objectName: (sessionStrip.strip.reference ? "referenceFilmstripLap-" : "activeFilmstripLap-") + proportionalLap.lapId
+                                    objectName: (sessionStrip.reference ? "referenceFilmstripLap-" : "activeFilmstripLap-") + proportionalLap.lapId
                                     radius: 3
-                                    width: proportionalLap.pinIncomplete ? 30 : Math.max(1, proportionalLap.flexibleLaneWidth * Math.max(1, proportionalLap.timeMs) / (sessionStrip.laps.fixedLapCount === sessionStrip.laps.rowCount ? sessionStrip.laps.totalTimeMs : sessionStrip.laps.flexibleTimeMs))
+                                    width: Math.max(1, (proportionalLapLane.width - Math.max(0, sessionStrip.laps.count - 1) * proportionalLapRow.spacing) * Math.max(1, proportionalLap.timeMs) / Math.max(1, sessionStrip.laps.totalTimeMs))
 
                                     Rectangle {
                                         anchors.bottom: parent.bottom
@@ -160,12 +159,12 @@ Rectangle {
                                         anchors.fill: parent
                                         anchors.leftMargin: 5
                                         anchors.rightMargin: 5
-                                        color: proportionalLap.selectedLap ? (sessionStrip.strip.reference ? Style.orangeColor : Style.accentColor) : proportionalLap.isFastest ? Style.greenColor : Style.foregroundColor
+                                        color: proportionalLap.selectedLap ? (sessionStrip.reference ? Style.orangeColor : Style.accentColor) : proportionalLap.isFastest ? Style.greenColor : Style.foregroundColor
                                         elide: Text.ElideRight
                                         font.bold: proportionalLap.selectedLap || proportionalLap.confidenceLap
                                         font.family: Style.monoFontFamily
                                         font.pixelSize: 9
-                                        text: proportionalLap.pinIncomplete ? proportionalLap.label : proportionalLap.timeText
+                                        text: proportionalLap.isComplete ? proportionalLap.timeText : proportionalLap.label
                                         verticalAlignment: Text.AlignVCenter
                                     }
                                     MouseArea {
@@ -178,17 +177,17 @@ Rectangle {
                                         onClicked: mouse => {
                                             if (mouse.button === Qt.RightButton) {
                                                 filmstrip.pointerTooltipDismissed(proportionalLap.tooltipOwner);
-                                                filmstrip.lapMenuRequested(sessionStrip.strip.sessionKey, proportionalLap.lapId, mouse.x, mouse.y);
+                                                Store.compareLap(sessionStrip.sessionKey, proportionalLap.lapId);
                                                 return;
                                             }
-                                            if (sessionStrip.strip.reference)
-                                                Store.compareLap(sessionStrip.strip.sessionKey, proportionalLap.lapId);
+                                            if (sessionStrip.reference)
+                                                Store.compareLap(sessionStrip.sessionKey, proportionalLap.lapId);
                                             else
-                                                Store.selectLap(sessionStrip.strip.sessionKey, proportionalLap.lapId);
+                                                Store.selectLap(sessionStrip.sessionKey, proportionalLap.lapId);
                                         }
                                         onEntered: {
                                             const point = proportionalLapMouse.mapToItem(Overlay.overlay, proportionalLapMouse.mouseX, proportionalLapMouse.mouseY);
-                                            filmstrip.pointerTooltipRequested(proportionalLap.tooltipOwner, proportionalLap.timeText + " · " + proportionalLap.label + (proportionalLap.confidenceLap ? " · Consistency cohort" : ""), point.x, point.y);
+                                            filmstrip.pointerTooltipRequested(proportionalLap.tooltipOwner, proportionalLap.hoverText + (proportionalLap.confidenceLap ? " · Consistency cohort" : ""), point.x, point.y);
                                         }
                                         onExited: filmstrip.pointerTooltipDismissed(proportionalLap.tooltipOwner)
                                         onPositionChanged: mouse => {

--- a/src/app/LibraryModel.cpp
+++ b/src/app/LibraryModel.cpp
@@ -8,7 +8,7 @@
 
 // ── LibraryModel ────────────────────────────────────────────────────
 
-LibraryModel::LibraryModel(QObject* parent) : QAbstractListModel(parent) {}
+LibraryModel::LibraryModel(QObject* parent) : IdentityListModel(parent) {}
 
 QHash<int, QByteArray> LibraryModel::roleNames() const {
     return {
@@ -147,23 +147,21 @@ LibraryModel::Node LibraryModel::fromVariantMap(const QVariantMap& vm) {
 }
 
 void LibraryModel::setTree(const QVariantList& sources) {
-    beginResetModel();
-    rootNodes_.clear();
-    rootNodes_.reserve(sources.size());
+    QVector<Node> nextRoots;
+    nextRoots.reserve(sources.size());
     for (const QVariant& source : sources)
-        rootNodes_.append(fromVariantMap(source.toMap()));
+        nextRoots.append(fromVariantMap(source.toMap()));
     sessionAncestors_.clear();
-    buildAncestorCache(Node{}, {});  // clear
-    // Build ancestor cache for revealSession.
-    for (const Node& node : std::as_const(rootNodes_)) {
+    for (const Node& node : std::as_const(nextRoots)) {
         QStringList ancestors;
         buildAncestorCache(node, ancestors);
     }
     if (filtering_)
-        for (Node& node : rootNodes_) expandAll(node);
-    flatten();
+        for (Node& node : nextRoots) expandAll(node);
+    QVector<FlatRow> nextFlat = flattenTree(nextRoots);
+    applyFlat(std::move(nextFlat));
+    rootNodes_ = std::move(nextRoots);
     collectFacets();
-    endResetModel();
     emit refreshed();
 }
 
@@ -198,15 +196,16 @@ void LibraryModel::expandAll(Node& node) const {
     for (Node& child : node.children) expandAll(child);
 }
 
-void LibraryModel::flatten() {
-    flat_.clear();
-    for (const Node& node : std::as_const(rootNodes_)) {
+QVector<LibraryModel::FlatRow> LibraryModel::flattenTree(
+    const QVector<Node>& roots) const {
+    QVector<FlatRow> flat;
+    for (const Node& node : roots) {
         const bool expanded = filtering_ || nodeExpanded(node.kind, node.path);
-        flat_.append({&node, 0, expanded,
-                      node.kind == QLatin1String("file") &&
-                          !node.key.isEmpty() && node.key == primaryKey_,
-                      node.kind == QLatin1String("file") &&
-                          !node.key.isEmpty() && node.key == referenceKey_});
+        flat.append({&node, 0, expanded,
+                     node.kind == QLatin1String("file") &&
+                         !node.key.isEmpty() && node.key == primaryKey_,
+                     node.kind == QLatin1String("file") &&
+                         !node.key.isEmpty() && node.key == referenceKey_});
         if (expanded) {
             // Recurse into children
             QVector<const Node*> stack;
@@ -220,13 +219,13 @@ void LibraryModel::flatten() {
                 int indent = indentStack.takeLast();
                 const bool curExpanded =
                     filtering_ || nodeExpanded(current->kind, current->path);
-                flat_.append({current, indent, curExpanded,
-                              current->kind == QLatin1String("file") &&
-                                  !current->key.isEmpty() &&
-                                  current->key == primaryKey_,
-                              current->kind == QLatin1String("file") &&
-                                  !current->key.isEmpty() &&
-                                  current->key == referenceKey_});
+                flat.append({current, indent, curExpanded,
+                             current->kind == QLatin1String("file") &&
+                                 !current->key.isEmpty() &&
+                                 current->key == primaryKey_,
+                             current->kind == QLatin1String("file") &&
+                                 !current->key.isEmpty() &&
+                                 current->key == referenceKey_});
                 if (curExpanded) {
                     for (int i = current->children.size() - 1; i >= 0; --i) {
                         stack.append(&current->children[i]);
@@ -236,6 +235,33 @@ void LibraryModel::flatten() {
             }
         }
     }
+    return flat;
+}
+
+void LibraryModel::applyFlat(QVector<FlatRow> next) {
+    replaceByIdentity(
+        flat_, std::move(next),
+        [this](const FlatRow& row) {
+            return row.node ? rowIdentity(*row.node) : QString();
+        },
+        [](const FlatRow& left, const FlatRow& right) {
+            if (!left.node || !right.node) return left.node == right.node;
+            const Node& a = *left.node;
+            const Node& b = *right.node;
+            return left.indent == right.indent &&
+                   left.expanded == right.expanded &&
+                   left.isPrimary == right.isPrimary &&
+                   left.isReference == right.isReference &&
+                   a.title == b.title && a.bestLapText == b.bestLapText &&
+                   a.driver == b.driver && a.sessionName == b.sessionName &&
+                   a.track == b.track && a.lapCount == b.lapCount &&
+                   a.childCount == b.childCount && a.available == b.available &&
+                   a.pinned == b.pinned && a.isVideo == b.isVideo &&
+                   a.hasSession == b.hasSession && a.key == b.key &&
+                   a.startTimeText == b.startTimeText &&
+                   a.driveTimeText == b.driveTimeText &&
+                   a.sessionDayKey == b.sessionDayKey;
+        });
 }
 
 void LibraryModel::collectFacets() {
@@ -264,9 +290,7 @@ void LibraryModel::toggleNode(const QString& kind, const QString& path) {
     const QString key = nodeKey(kind, path);
     const bool currently = nodeExpanded(kind, path);
     expanded_[key] = !currently;
-    beginResetModel();
-    flatten();
-    endResetModel();
+    applyFlat(flattenTree(rootNodes_));
 }
 
 bool LibraryModel::revealSession(const QString& sessionKey) {
@@ -280,11 +304,7 @@ bool LibraryModel::revealSession(const QString& sessionKey) {
             changed = true;
         }
     }
-    if (changed) {
-        beginResetModel();
-        flatten();
-        endResetModel();
-    }
+    if (changed) applyFlat(flattenTree(rootNodes_));
     return changed;
 }
 
@@ -370,11 +390,9 @@ void LibraryModel::updateSelection(const QString& primaryKey,
 void LibraryModel::setFilteringActive(bool active) {
     if (filtering_ == active) return;
     filtering_ = active;
-    beginResetModel();
     if (active)
         for (Node& node : rootNodes_) expandAll(node);
-    flatten();
-    endResetModel();
+    applyFlat(flattenTree(rootNodes_));
 }
 
 QStringList LibraryModel::filePaths() const {
@@ -466,16 +484,27 @@ void LibraryFilterModel::setSelectedKind(const QString& kind) {
     });
 }
 
+void LibraryFilterModel::setSelectedDay(const QString& day) {
+    if (selectedDay_ == day) return;
+    changeFilter([&] {
+        selectedDay_ = day;
+        emit selectedDayChanged();
+        syncFilteringActive();
+    });
+}
+
 bool LibraryFilterModel::facetsActive() const {
     return !selectedDrivers_.isEmpty() || !selectedYears_.isEmpty() ||
-           !selectedTrack_.isEmpty() || !selectedKind_.isEmpty();
+           !selectedTrack_.isEmpty() || !selectedKind_.isEmpty() ||
+           !selectedDay_.isEmpty();
 }
 
 bool LibraryFilterModel::rowPassesFacets(int sourceRow) const {
     if (!source_) return true;
     const QModelIndex idx = source_->index(sourceRow);
     if (selectedDrivers_.isEmpty() && selectedYears_.isEmpty() &&
-        selectedTrack_.isEmpty() && selectedKind_.isEmpty())
+        selectedTrack_.isEmpty() && selectedKind_.isEmpty() &&
+        selectedDay_.isEmpty())
         return true;
     const QString kind = idx.data(LibraryModel::KindRole).toString();
     // Only filter file rows; non-file rows pass (they are kept by
@@ -504,6 +533,11 @@ bool LibraryFilterModel::rowPassesFacets(int sourceRow) const {
         if (selectedKind_ == QLatin1String("video") && !isVideo) return false;
         if (selectedKind_ == QLatin1String("telemetry") && isVideo)
             return false;
+    }
+    if (!selectedDay_.isEmpty()) {
+        const QString day =
+            idx.data(LibraryModel::SessionDayKeyRole).toString();
+        if (day != selectedDay_) return false;
     }
     return true;
 }
@@ -545,6 +579,11 @@ bool LibraryFilterModel::filterAcceptsRow(
         if (selectedKind_ == QLatin1String("video") && !isVideo) return false;
         if (selectedKind_ == QLatin1String("telemetry") && isVideo)
             return false;
+    }
+    if (!selectedDay_.isEmpty()) {
+        const QString day =
+            idx.data(LibraryModel::SessionDayKeyRole).toString();
+        if (day != selectedDay_) return false;
     }
 
     // Text search: case-insensitive substring across multiple fields.

--- a/src/app/LibraryModel.h
+++ b/src/app/LibraryModel.h
@@ -121,6 +121,7 @@ public:
     /// Update primary/reference highlighting on all rows.
     void updateSelection(const QString& primaryKey,
                          const QString& referenceKey);
+    QString primarySessionKey() const { return primaryKey_; }
 
     /// True when any facet filter or text search is active (all nodes
     /// expand while filtering).

--- a/src/app/LibraryModel.h
+++ b/src/app/LibraryModel.h
@@ -12,9 +12,9 @@
 
 #pragma once
 
-#include <QAbstractListModel>
-#include <QHash>
 #include "FilterChange.h"
+#include "ModelDiff.h"
+#include <QHash>
 
 #include <QSortFilterProxyModel>
 #include <QStringList>
@@ -23,7 +23,7 @@
 #include <QVector>
 #include <QtQml/qqmlregistration.h>
 
-class LibraryModel : public QAbstractListModel {
+class LibraryModel : public IdentityListModel {
     Q_OBJECT
     QML_ELEMENT
     Q_PROPERTY(QStringList driverPills READ driverPills NOTIFY refreshed)
@@ -143,7 +143,11 @@ private:
     };
 
     static Node fromVariantMap(const QVariantMap& vm);
-    void flatten();
+    QString rowIdentity(const Node& node) const {
+        return node.kind + QChar(0) + node.path + QChar(0) + node.key;
+    }
+    QVector<FlatRow> flattenTree(const QVector<Node>& roots) const;
+    void applyFlat(QVector<FlatRow> next);
     void collectFacets();
     void expandAll(Node& node) const;
     bool nodeExpanded(const QString& kind, const QString& path) const;
@@ -179,6 +183,8 @@ class LibraryFilterModel : public FilterChangeProxyModel {
                    NOTIFY selectedTrackChanged)
     Q_PROPERTY(QString selectedKind READ selectedKind WRITE setSelectedKind
                    NOTIFY selectedKindChanged)
+    Q_PROPERTY(QString selectedDay READ selectedDay WRITE setSelectedDay NOTIFY
+                   selectedDayChanged)
 public:
     explicit LibraryFilterModel(QObject* parent = nullptr);
 
@@ -197,6 +203,9 @@ public:
     QString selectedKind() const { return selectedKind_; }
     void setSelectedKind(const QString& kind);
 
+    QString selectedDay() const { return selectedDay_; }
+    void setSelectedDay(const QString& day);
+
     bool filterAcceptsRow(int sourceRow,
                           const QModelIndex& sourceParent) const override;
 
@@ -210,6 +219,7 @@ signals:
     void selectedYearsChanged();
     void selectedTrackChanged();
     void selectedKindChanged();
+    void selectedDayChanged();
 
 private:
     void syncFilteringActive();
@@ -221,5 +231,6 @@ private:
     QStringList selectedYears_;
     QString selectedTrack_;
     QString selectedKind_;
+    QString selectedDay_;
     LibraryModel* source_ = nullptr;
 };

--- a/src/app/LuaRename.cpp
+++ b/src/app/LuaRename.cpp
@@ -1,0 +1,225 @@
+#include "LuaRename.h"
+
+#include <QElapsedTimer>
+#include <QMetaType>
+#include <QVariant>
+
+#include <sol/sol.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+extern "C" {
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+}
+
+namespace omatrack {
+namespace {
+
+constexpr const char* kAbortKey = "omatrack.abort";
+
+struct AllocState {
+    size_t used = 0;
+    size_t cap = 0;
+    bool overflow = false;
+};
+
+struct HookState {
+    QElapsedTimer clock;
+    int timeoutMs = 50;
+    AllocState* alloc = nullptr;
+    bool aborted = false;
+    const char* reason = nullptr;
+};
+
+void abortLua(lua_State* L, HookState* hook, const char* reason) {
+    hook->aborted = true;
+    hook->reason = reason;
+    lua_pushstring(L, reason);
+    lua_error(L);
+}
+
+void* cappedAlloc(void* ud, void* ptr, size_t osize, size_t nsize) {
+    auto* alloc = static_cast<AllocState*>(ud);
+    size_t current = alloc->used;
+    if (ptr) current -= osize;
+    if (nsize == 0) {
+        alloc->used = current;
+        std::free(ptr);
+        return nullptr;
+    }
+    if (current + nsize > alloc->cap) {
+        alloc->overflow = true;
+        return nullptr;
+    }
+    void* next = std::realloc(ptr, nsize);
+    if (next) alloc->used = current + nsize;
+    return next;
+}
+
+void countHook(lua_State* L, lua_Debug*) {
+    lua_pushstring(L, kAbortKey);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+    auto* hook = static_cast<HookState*>(lua_touserdata(L, -1));
+    lua_pop(L, 1);
+    if (!hook) return;
+    if (hook->alloc && hook->alloc->overflow)
+        abortLua(L, hook, "rename script exceeded memory cap");
+    if (hook->clock.hasExpired(hook->timeoutMs))
+        abortLua(L, hook, "rename script timed out");
+}
+
+void stripUnsafe(lua_State* L) {
+    const char* names[] = {"load", "loadfile", "dofile", "setmetatable",
+                           "loadstring"};
+    for (const char* name : names) {
+        lua_pushnil(L);
+        lua_setglobal(L, name);
+    }
+    lua_getglobal(L, "string");
+    if (lua_istable(L, -1)) {
+        lua_pushnil(L);
+        lua_setfield(L, -2, "dump");
+    }
+    lua_pop(L, 1);
+}
+
+void pushCtx(lua_State* L, const QVariantMap& ctx) {
+    // sol2 builds a plain table of strings/numbers — never Qt usertypes.
+    // create_table can leave extras on the stack; pin the function slot
+    // and push exactly one argument.
+    const int fnTop = lua_gettop(L);
+    sol::state_view lua(L);
+    sol::table table = lua.create_table(0, ctx.size());
+    for (auto it = ctx.cbegin(); it != ctx.cend(); ++it) {
+        const std::string key = it.key().toStdString();
+        const QVariant value = it.value();
+        switch (value.typeId()) {
+            case QMetaType::Int:
+            case QMetaType::LongLong:
+            case QMetaType::UInt:
+            case QMetaType::ULongLong:
+            case QMetaType::Double:
+            case QMetaType::Float: table[key] = value.toDouble(); break;
+            case QMetaType::Bool: table[key] = value.toBool(); break;
+            default: table[key] = value.toString().toStdString(); break;
+        }
+    }
+    lua_settop(L, fnTop);
+    sol::stack::push(L, table);
+}
+
+QString failMessage(const AllocState& alloc, const HookState& hook,
+                    lua_State* L) {
+    if (alloc.overflow)
+        return QStringLiteral("rename script exceeded memory cap");
+    if (hook.reason) return QString::fromUtf8(hook.reason);
+    if (const char* message = lua_tostring(L, -1))
+        return QString::fromUtf8(message);
+    return QStringLiteral("rename script failed");
+}
+
+}  // namespace
+
+QString exampleLuaRenameScript() {
+    return QStringLiteral(
+        "-- rename(ctx) returns a destination-relative path.\n"
+        "-- ctx.track / date / session / original / driver / car\n"
+        "function rename(ctx)\n"
+        "  return ctx.track .. \"/\" .. ctx.date .. \"/\" .. ctx.session"
+        " .. \"/\" .. ctx.original\n"
+        "end\n");
+}
+
+LuaRenameResult runLuaRename(const QString& script, const QVariantMap& ctx,
+                             int timeoutMs, size_t memoryCapBytes) {
+    LuaRenameResult result;
+    const QString trimmed = script.trimmed();
+    if (trimmed.isEmpty()) {
+        result.ok = true;
+        return result;
+    }
+
+    AllocState alloc;
+    alloc.cap = memoryCapBytes;
+    lua_State* L = lua_newstate(cappedAlloc, &alloc);
+    if (!L) {
+        result.error = QStringLiteral("rename script exceeded memory cap");
+        return result;
+    }
+
+    luaL_requiref(L, LUA_GNAME, luaopen_base, 1);
+    lua_pop(L, 1);
+    luaL_requiref(L, LUA_STRLIBNAME, luaopen_string, 1);
+    lua_pop(L, 1);
+    luaL_requiref(L, LUA_TABLIBNAME, luaopen_table, 1);
+    lua_pop(L, 1);
+    luaL_requiref(L, LUA_MATHLIBNAME, luaopen_math, 1);
+    lua_pop(L, 1);
+    luaL_requiref(L, LUA_UTF8LIBNAME, luaopen_utf8, 1);
+    lua_pop(L, 1);
+    stripUnsafe(L);
+
+    HookState hook;
+    hook.timeoutMs = std::max(1, timeoutMs);
+    hook.alloc = &alloc;
+    hook.clock.start();
+    lua_pushstring(L, kAbortKey);
+    lua_pushlightuserdata(L, &hook);
+    lua_rawset(L, LUA_REGISTRYINDEX);
+    lua_sethook(L, countHook, LUA_MASKCOUNT, 1000);
+
+    const std::string source = trimmed.toStdString();
+    if (luaL_loadbuffer(L, source.data(), source.size(), "=rename") != LUA_OK ||
+        lua_pcall(L, 0, 0, 0) != LUA_OK) {
+        result.error = failMessage(alloc, hook, L);
+        lua_close(L);
+        return result;
+    }
+
+    lua_getglobal(L, "rename");
+    if (!lua_isfunction(L, -1)) {
+        result.error = QStringLiteral("rename script must define rename(ctx)");
+        lua_close(L);
+        return result;
+    }
+    pushCtx(L, ctx);
+    if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
+        result.error = failMessage(alloc, hook, L);
+        lua_close(L);
+        return result;
+    }
+    if (lua_isnil(L, -1)) {
+        result.error = QStringLiteral("Rename produced a null path");
+        lua_close(L);
+        return result;
+    }
+    if (!lua_isstring(L, -1)) {
+        result.error = QStringLiteral("rename(ctx) must return a string");
+        lua_close(L);
+        return result;
+    }
+    size_t length = 0;
+    const char* relative = lua_tolstring(L, -1, &length);
+    if (!relative) {
+        result.error = QStringLiteral("rename(ctx) must return a string");
+        lua_close(L);
+        return result;
+    }
+    std::string path(relative, length);
+    if (path.find('\0') != std::string::npos) {
+        result.error = QStringLiteral("Rename produced a null byte");
+        lua_close(L);
+        return result;
+    }
+    result.relativePath = QString::fromStdString(path);
+    result.ok = true;
+    lua_close(L);
+    return result;
+}
+
+}  // namespace omatrack

--- a/src/app/LuaRename.h
+++ b/src/app/LuaRename.h
@@ -1,0 +1,30 @@
+// Sandboxed Lua 5.4 rename scripts for USB copy.
+//
+// Lives in src/app: omatrack_core stays Qt- and Lua-free. The sandbox opens
+// only base/string/table/math/utf8, strips load/loadfile/dofile/setmetatable,
+// caps memory (string.rep bypasses the instruction hook), and aborts on a
+// COUNT hook plus wall-clock. ctx is a plain table of strings and numbers.
+#pragma once
+
+#include <QString>
+#include <QVariantMap>
+
+namespace omatrack {
+
+struct LuaRenameResult {
+    bool ok = false;
+    QString relativePath;
+    QString error;
+};
+
+/// Default example shown in preferences — not loaded as a plugin.
+QString exampleLuaRenameScript();
+
+/// Run `script` off whatever thread the caller is on. `rename(ctx)` must
+/// return a relative path string. Empty script is a no-op (ok, empty path)
+/// so the format string remains the default layout.
+LuaRenameResult runLuaRename(const QString& script, const QVariantMap& ctx,
+                             int timeoutMs = 50,
+                             size_t memoryCapBytes = 1024 * 1024);
+
+}  // namespace omatrack

--- a/src/app/Main.qml
+++ b/src/app/Main.qml
@@ -10,22 +10,20 @@ import QtQuick.Layouts
 ApplicationWindow {
     id: root
 
-    property bool _lapStripDirty: true
-    property string activeSessionKey: ""
+    readonly property string activeSessionKey: Store.primarySessionKey
     property string activeSessionName: ""
 
     // Supplied by QQmlApplicationEngine::setInitialProperties in main().
     required property bool autotestWindows
 
-    // Caches the root itself renders: the lap filmstrip, the damper-alignment
-    // traces, and the telemetry directories listed in the drawer. Each is
-    // refreshed from the matching Store signal in the Connections block below.
+    // Caches the root itself renders: damper-alignment traces and the
+    // telemetry directories listed in the drawer. The filmstrip binds to
+    // Store.filmstripSessions. Each cache is refreshed from Store signals.
     property bool deltaTraceVisible: false
     property var directoryRows: []
     // Side by side only when the reference lap has its own recording and the
     // primary video is telemetry-linked, so both can share one alignment map.
     readonly property bool dualVideo: telemetryVideoActive && Store.compareVideoSource.toString() !== "" && Store.compareVideoSource.toString() !== Store.primaryVideoSource.toString()
-    property var filmstripSessions: []
     // Rapid selection changes update one pending source instead of queuing
     // stale callLater closures that can reopen the previous recording.
     property url pendingVideoSource: ""
@@ -33,7 +31,7 @@ ApplicationWindow {
     property string pointerTooltipText: ""
     property real pointerTooltipX: 0
     property real pointerTooltipY: 0
-    property string referenceSessionKey: ""
+    readonly property string referenceSessionKey: Store.compareSessionKey
     property string referenceSessionName: ""
     property bool sidebarVisible: true
     readonly property bool standaloneVideoActive: root.videoVisible && !root.telemetryVideoActive
@@ -94,20 +92,6 @@ ApplicationWindow {
         root.telemetryVideoActive = false;
         root.videoVisible = false;
     }
-    function lapStripEntry(key, reference) {
-        const lapsModel = reference ? Store.compareLaps : Store.primaryLaps;
-        return {
-            sessionKey: key,
-            driverName: Store.driverDisplayName(key),
-            bestTime: root.sessionInfoForKey(key)?.bestLapText || "",
-            reference: reference,
-            lapsModel: lapsModel,
-            lapsCount: lapsModel.rowCount,
-            fixedLapCount: lapsModel.fixedLapCount,
-            flexibleTimeMs: lapsModel.flexibleTimeMs,
-            totalTimeMs: lapsModel.totalTimeMs
-        };
-    }
     function movePointerTooltip(owner: string, x: real, y: real): void {
         if (root.pointerTooltipOwner !== owner)
             return;
@@ -140,21 +124,8 @@ ApplicationWindow {
         root.deltaTraceVisible = Store.channelVisible("delta");
     }
     function refreshLapStrip() {
-        const newActive = Store.primarySessionKey;
-        const newReference = Store.compareSessionKey;
-        if (!root._lapStripDirty && newActive === root.activeSessionKey && newReference === root.referenceSessionKey)
-            return;
-        root._lapStripDirty = false;
-        root.activeSessionKey = newActive;
-        root.referenceSessionKey = newReference;
-        root.activeSessionName = root.sessionNameForKey(root.activeSessionKey);
-        root.referenceSessionName = root.sessionNameForKey(root.referenceSessionKey);
-        let strips = [];
-        if (root.activeSessionKey !== "")
-            strips.push(root.lapStripEntry(root.activeSessionKey, false));
-        if (root.referenceSessionKey !== "" && root.referenceSessionKey !== root.activeSessionKey)
-            strips.push(root.lapStripEntry(root.referenceSessionKey, true));
-        root.filmstripSessions = strips;
+        root.activeSessionName = root.sessionNameForKey(Store.primarySessionKey);
+        root.referenceSessionName = root.sessionNameForKey(Store.compareSessionKey);
     }
     // A streamed recording is reached through a signature that expires, and a
     // laptop closed at the circuit and opened on the plane home wakes up
@@ -1174,7 +1145,6 @@ ApplicationWindow {
             root.syncTelemetryVideo();
         }
         function onSessionsChanged(): void {
-            root._lapStripDirty = true;
             root.refreshLapStrip();
             root.directoryRows = Store.sessionDirectories();
         }
@@ -1398,26 +1368,6 @@ ApplicationWindow {
         titleText: trace.spanHoverTitle
         visible: trace.spanHoverVisible
     }
-    Menu {
-        id: lapMenu
-
-        property int lapId: -1
-        property string sessionKey: ""
-
-        MenuItem {
-            enabled: lapMenu.sessionKey !== Store.primarySessionKey || lapMenu.lapId !== Store.primaryLapIndex
-            text: "Set as active lap"
-
-            onTriggered: Store.selectLap(lapMenu.sessionKey, lapMenu.lapId)
-        }
-        MenuItem {
-            enabled: lapMenu.sessionKey !== Store.primarySessionKey || lapMenu.lapId !== Store.primaryLapIndex
-            text: "Set as reference lap"
-
-            onTriggered: Store.compareLap(lapMenu.sessionKey, lapMenu.lapId)
-        }
-    }
-
     // ══ body ════════════════════════════════════════════════════════
     ColumnLayout {
         anchors.fill: parent
@@ -1426,13 +1376,6 @@ ApplicationWindow {
         LapFilmstrip {
             id: lapFilmstrip
 
-            sessions: root.filmstripSessions
-
-            onLapMenuRequested: (sessionKey, lapId, x, y) => {
-                lapMenu.sessionKey = sessionKey;
-                lapMenu.lapId = lapId;
-                lapMenu.popup(lapFilmstrip, x, y);
-            }
             onPointerTooltipDismissed: owner => root.dismissPointerTooltip(owner)
             onPointerTooltipMoved: (owner, x, y) => root.movePointerTooltip(owner, x, y)
             onPointerTooltipRequested: (owner, text, x, y) => root.showPointerTooltip(owner, text, x, y)

--- a/src/app/Main.qml
+++ b/src/app/Main.qml
@@ -358,6 +358,17 @@ ApplicationWindow {
         videoFullscreen: root.videoFullscreen
     }
     Shortcut {
+        enabled: root.videoFullscreen || Store.focusedCorner >= 0
+        sequence: "Escape"
+
+        onActivated: {
+            if (root.videoFullscreen)
+                root.videoSetFullscreen(false);
+            else
+                Store.clearCornerFocus();
+        }
+    }
+    Shortcut {
         enabled: {
             const item = root.activeFocusItem;
             if (!item)
@@ -368,17 +379,6 @@ ApplicationWindow {
         sequence: "X"
 
         onActivated: Store.swapPrimaryWithReference()
-    }
-    Shortcut {
-        enabled: root.videoFullscreen || Store.focusedCorner >= 0
-        sequence: "Escape"
-
-        onActivated: {
-            if (root.videoFullscreen)
-                root.videoSetFullscreen(false);
-            else
-                Store.clearCornerFocus();
-        }
     }
     DropArea {
         id: fileDropArea

--- a/src/app/Main.qml
+++ b/src/app/Main.qml
@@ -387,6 +387,18 @@ ApplicationWindow {
         videoFullscreen: root.videoFullscreen
     }
     Shortcut {
+        enabled: {
+            const item = root.activeFocusItem;
+            if (!item)
+                return true;
+            return !(item instanceof TextInput || item instanceof TextEdit);
+        }
+        objectName: "swapReferenceShortcut"
+        sequence: "X"
+
+        onActivated: Store.swapPrimaryWithReference()
+    }
+    Shortcut {
         enabled: root.videoFullscreen || Store.focusedCorner >= 0
         sequence: "Escape"
 
@@ -900,6 +912,7 @@ ApplicationWindow {
 
             HoverHandler {
                 id: videoControlsHover
+
             }
             MouseArea {
                 anchors.fill: parent
@@ -1361,9 +1374,11 @@ ApplicationWindow {
     }
     ChannelsWindow {
         id: channelsWindow
+
     }
     PreferencesWindow {
         id: settingsWindow
+
     }
     ToolTip {
         id: pointerTooltip
@@ -1579,6 +1594,11 @@ ApplicationWindow {
 
                         anchors.fill: parent
                         objectName: "videoStageSlot"
+
+                        UsbCopyOverlay {
+                            anchors.fill: parent
+                            visible: Store.usbCopyVisible
+                        }
                     }
                 }
                 Rectangle {

--- a/src/app/ModelDiff.h
+++ b/src/app/ModelDiff.h
@@ -1,0 +1,80 @@
+// Identity-preserving list updates for QAbstractListModel.
+//
+// beginResetModel() rebuilds every QML delegate and jumps Flickable.contentY
+// to 0. Refresh and filter must insert/remove/dataChanged against a stable
+// row identity instead. LibraryModel and the StoreModels share this helper.
+#pragma once
+
+#include <QAbstractListModel>
+#include <QHash>
+#include <QString>
+#include <QVector>
+#include <utility>
+
+class IdentityListModel : public QAbstractListModel {
+public:
+    using QAbstractListModel::QAbstractListModel;
+
+protected:
+    /// Replace `rows` with `next` by identity. Existing identities keep
+    /// their delegates; missing rows are removed and new ones inserted.
+    /// `identity` returns a stable key; rows with the same key are assigned
+    /// through and emit dataChanged when `unchanged` is false.
+    template <typename T, typename IdentityFn, typename UnchangedFn>
+    void replaceByIdentity(QVector<T>& rows, QVector<T> next,
+                           IdentityFn identity, UnchangedFn unchanged) {
+        QHash<QString, int> nextIndex;
+        nextIndex.reserve(next.size());
+        for (int i = 0; i < next.size(); ++i)
+            nextIndex.insert(identity(next.at(i)), i);
+
+        for (int i = rows.size() - 1; i >= 0; --i) {
+            if (nextIndex.contains(identity(rows.at(i)))) continue;
+            beginRemoveRows(QModelIndex(), i, i);
+            rows.removeAt(i);
+            endRemoveRows();
+        }
+
+        QHash<QString, int> currentIndex;
+        const auto rebuildCurrent = [&]() {
+            currentIndex.clear();
+            currentIndex.reserve(rows.size());
+            for (int i = 0; i < rows.size(); ++i)
+                currentIndex.insert(identity(rows.at(i)), i);
+        };
+        rebuildCurrent();
+
+        for (int i = 0; i < next.size(); ++i) {
+            const QString id = identity(next.at(i));
+            const auto found = currentIndex.constFind(id);
+            if (found == currentIndex.cend()) {
+                beginInsertRows(QModelIndex(), i, i);
+                rows.insert(i, std::move(next[i]));
+                endInsertRows();
+                rebuildCurrent();
+                continue;
+            }
+            const int from = found.value();
+            if (from != i) {
+                // Qt documents destination as the index *before* the move
+                // for a downward move; beginMoveRows wants the row the
+                // source will sit at after removal of `from`.
+                const int destination = from < i ? i + 1 : i;
+                if (beginMoveRows(QModelIndex(), from, from, QModelIndex(),
+                                  destination)) {
+                    rows.move(from, i);
+                    endMoveRows();
+                }
+                rebuildCurrent();
+            }
+            const bool same = unchanged(rows[i], next.at(i));
+            rows[i] = std::move(next[i]);
+            if (!same) emit dataChanged(index(i), index(i));
+        }
+        if (rows.size() > next.size()) {
+            beginRemoveRows(QModelIndex(), next.size(), rows.size() - 1);
+            rows.resize(next.size());
+            endRemoveRows();
+        }
+    }
+};

--- a/src/app/PathJail.cpp
+++ b/src/app/PathJail.cpp
@@ -1,0 +1,121 @@
+#include "PathJail.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QVector>
+
+namespace omatrack {
+namespace {
+
+bool hasNull(const QString& text) { return text.contains(QChar(0)); }
+
+bool isWindowsDrive(const QString& text) {
+    if (text.size() < 2) return false;
+    const QChar letter = text[0];
+    if (!letter.isLetter()) return false;
+    return text[1] == QLatin1Char(':');
+}
+
+bool hasDotDotComponent(const QString& cleaned) {
+    const QStringList parts = QDir::fromNativeSeparators(cleaned).split(
+        QLatin1Char('/'), Qt::SkipEmptyParts);
+    return parts.contains(QStringLiteral(".."));
+}
+
+QString destCanonical(const QString& destRoot) {
+    const QString absolute =
+        QDir::cleanPath(QFileInfo(destRoot).absoluteFilePath());
+    const QString canonical = QFileInfo(absolute).canonicalFilePath();
+    return canonical.isEmpty() ? absolute : canonical;
+}
+
+bool staysUnder(const QString& parent, const QString& dest) {
+    if (parent == dest) return true;
+    const QString prefix =
+        dest.endsWith(QLatin1Char('/')) ? dest : dest + QLatin1Char('/');
+    return parent.startsWith(prefix);
+}
+
+}  // namespace
+
+QString defaultCopyFormat() {
+    return QStringLiteral("{track}/{date}/{session}/{original}");
+}
+
+QString expandCopyFormat(const QString& format, const QVariantMap& ctx) {
+    QString result = format;
+    static const QRegularExpression token(
+        QStringLiteral("\\{([A-Za-z0-9_]+)\\}"));
+    QRegularExpressionMatchIterator it = token.globalMatch(format);
+    QVector<QRegularExpressionMatch> matches;
+    while (it.hasNext()) matches.append(it.next());
+    for (int i = matches.size() - 1; i >= 0; --i) {
+        const QRegularExpressionMatch match = matches.at(i);
+        const QString key = match.captured(1);
+        const QString value = ctx.value(key).toString();
+        result.replace(match.capturedStart(), match.capturedLength(), value);
+    }
+    return result;
+}
+
+bool isForbiddenRelative(const QString& relative) {
+    if (relative.isEmpty() || hasNull(relative)) return true;
+    const QString slash = QDir::fromNativeSeparators(relative.trimmed());
+    if (slash.startsWith(QLatin1Char('/'))) return true;
+    if (slash.startsWith(QStringLiteral("//"))) return true;
+    if (isWindowsDrive(slash)) return true;
+    if (relative.contains(QStringLiteral("\\\\"))) return true;
+    if (relative.contains(QChar(0))) return true;
+    return false;
+}
+
+PathJailResult jailRelativePath(const QString& destRoot,
+                                const QString& relative) {
+    PathJailResult result;
+    if (destRoot.trimmed().isEmpty()) {
+        result.error = QStringLiteral("Destination folder is empty");
+        return result;
+    }
+    if (relative.trimmed().isEmpty()) {
+        result.error = QStringLiteral("Rename produced an empty path");
+        return result;
+    }
+    if (hasNull(relative)) {
+        result.error = QStringLiteral("Rename produced a null byte");
+        return result;
+    }
+    if (isForbiddenRelative(relative)) {
+        result.error = QStringLiteral("Rename produced an absolute path");
+        return result;
+    }
+    const QString cleanedRelative =
+        QDir::cleanPath(QDir::fromNativeSeparators(relative));
+    if (cleanedRelative.isEmpty() || cleanedRelative == QLatin1Char('.') ||
+        cleanedRelative == QStringLiteral("..") ||
+        hasDotDotComponent(cleanedRelative) ||
+        isForbiddenRelative(cleanedRelative)) {
+        result.error = QStringLiteral("Rename escaped the destination");
+        return result;
+    }
+
+    const QString dest = destCanonical(destRoot);
+    const QString full = QDir::cleanPath(QDir(dest).filePath(cleanedRelative));
+    if (full == dest) {
+        result.error = QStringLiteral("Rename targeted the destination root");
+        return result;
+    }
+    const QString parent = QFileInfo(full).path();
+    QString parentCanon = QFileInfo(parent).canonicalFilePath();
+    if (parentCanon.isEmpty()) parentCanon = QDir::cleanPath(parent);
+    if (!staysUnder(parentCanon, dest)) {
+        result.error = QStringLiteral("Rename escaped the destination");
+        return result;
+    }
+    result.ok = true;
+    result.absolutePath = full;
+    result.relativePath = cleanedRelative;
+    return result;
+}
+
+}  // namespace omatrack

--- a/src/app/PathJail.h
+++ b/src/app/PathJail.h
@@ -1,0 +1,33 @@
+// Destination-path jail for USB copy and Lua rename.
+//
+// A rename script or format string may only return a relative path. After
+// QDir::cleanPath(dest/relative) the parent must stay under dest; absolute
+// paths, null bytes, `..`, Windows drives, and UNC prefixes are rejected.
+#pragma once
+
+#include <QString>
+#include <QVariantMap>
+
+namespace omatrack {
+
+struct PathJailResult {
+    bool ok = false;
+    QString absolutePath;
+    QString relativePath;
+    QString error;
+};
+
+/// Default copy layout: `{track}/{date}/{session}/{original}`.
+QString defaultCopyFormat();
+
+/// Substitute `{token}` placeholders from `ctx`. Unknown tokens stay as-is.
+QString expandCopyFormat(const QString& format, const QVariantMap& ctx);
+
+/// True when `relative` is an absolute Unix path, a Windows drive path, or UNC.
+bool isForbiddenRelative(const QString& relative);
+
+/// Resolve `relative` under `destRoot`. Never creates files.
+PathJailResult jailRelativePath(const QString& destRoot,
+                                const QString& relative);
+
+}  // namespace omatrack

--- a/src/app/PreferencesEventPage.qml
+++ b/src/app/PreferencesEventPage.qml
@@ -1,0 +1,72 @@
+pragma ComponentBehavior: Bound
+import Omatrack
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: eventPage
+
+    objectName: "preferencesEventPage"
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+        spacing: 12
+
+        Label {
+            font.bold: true
+            font.pixelSize: 16
+            text: "Current event"
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.mutedTextColor
+            text: "When enabled, the sidebar shows one track and one day, and USB copy / Lua rename receive this session name."
+            wrapMode: Text.Wrap
+        }
+        Switch {
+            checked: Store.eventMode
+            text: "Event mode"
+
+            onToggled: Store.eventMode = checked
+        }
+        Label {
+            text: "Track"
+        }
+        ComboBox {
+            id: eventTrack
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: Style.controlHeight
+            currentIndex: Math.max(0, eventTrack.model.indexOf(Store.eventTrack))
+            model: [""].concat(Store.library.trackPills)
+
+            onActivated: index => Store.eventTrack = index <= 0 ? "" : eventTrack.model[index]
+        }
+        Label {
+            text: "Session name"
+        }
+        CompactTextField {
+            Layout.fillWidth: true
+            placeholderText: "c1"
+            text: Store.eventSession
+
+            onEditingFinished: Store.eventSession = text.trim()
+        }
+        Label {
+            text: "Event date"
+        }
+        CompactTextField {
+            Layout.fillWidth: true
+            placeholderText: "YYYY-MM-DD"
+            text: Store.eventDate
+
+            onEditingFinished: Store.eventDate = text.trim()
+        }
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/src/app/PreferencesLibraryPage.qml
+++ b/src/app/PreferencesLibraryPage.qml
@@ -390,6 +390,59 @@ Item {
             wrapMode: Text.WordWrap
         }
         Label {
+            font.bold: true
+            text: "USB copy"
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.mutedTextColor
+            font.pixelSize: Style.smallFontSize
+            text: "Detected sticks are browsed in the sidebar and never added to this list. Copy is explicit."
+            wrapMode: Text.Wrap
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+
+            CompactTextField {
+                Layout.fillWidth: true
+                placeholderText: "Destination folder"
+                text: Store.usbDest
+
+                onEditingFinished: Store.usbDest = text.trim()
+            }
+            CompactButton {
+                text: "Choose…"
+
+                onClicked: usbDestDialog.open()
+            }
+        }
+        CompactTextField {
+            Layout.fillWidth: true
+            placeholderText: "{track}/{date}/{session}/{original}"
+            text: Store.usbFormat
+
+            onEditingFinished: Store.usbFormat = text.trim()
+        }
+        Label {
+            color: Style.mutedTextColor
+            font.pixelSize: Style.smallFontSize
+            text: "Optional Lua rename(ctx). Empty uses the format string."
+        }
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 120
+
+            TextArea {
+                placeholderText: Store.luaRenameExample()
+                selectByMouse: true
+                text: Store.usbRenameScript
+                wrapMode: TextEdit.Wrap
+
+                onEditingFinished: Store.usbRenameScript = text
+            }
+        }
+        Label {
             Layout.fillWidth: true
             color: Style.dimTextColor
             elide: Text.ElideMiddle
@@ -397,6 +450,15 @@ Item {
             font.pixelSize: Style.smallFontSize
             text: "Configuration: " + Store.configFilePath()
         }
+    }
+    Platform.FolderDialog {
+        id: usbDestDialog
+
+        acceptLabel: "Use folder"
+        folder: Store.defaultTelemetryDirectoryUrl()
+        title: "USB copy destination"
+
+        onAccepted: Store.usbDest = libraryPage.toLocalPath(usbDestDialog.folder)
     }
     Dialog {
         id: clearCacheDialog

--- a/src/app/PreferencesOverlayPage.qml
+++ b/src/app/PreferencesOverlayPage.qml
@@ -1,0 +1,62 @@
+pragma ComponentBehavior: Bound
+import Omatrack
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Item {
+    id: overlayPage
+
+    objectName: "preferencesOverlayPage"
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+        spacing: 12
+
+        Label {
+            font.bold: true
+            font.pixelSize: 16
+            text: "Fullscreen overlay"
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.mutedTextColor
+            text: "Reference traces on the video HUD. White preset uses similar thickness to the primary traces."
+            wrapMode: Text.Wrap
+        }
+        Switch {
+            checked: Store.overlayRefWhite
+            text: "White reference lines"
+
+            onToggled: Store.overlayRefWhite = checked
+        }
+        Label {
+            text: "Reference style"
+        }
+        ComboBox {
+            id: refStyle
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: Style.controlHeight
+            currentIndex: Math.max(0, refStyle.model.indexOf(Store.overlayRefStyle))
+            model: ["dashed", "dotted", "solid"]
+
+            onActivated: index => Store.overlayRefStyle = refStyle.model[index]
+        }
+        Label {
+            text: "Reference color"
+        }
+        CompactTextField {
+            Layout.fillWidth: true
+            enabled: !Store.overlayRefWhite
+            text: Store.overlayRefColor
+
+            onEditingFinished: Store.overlayRefColor = text.trim()
+        }
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/src/app/PreferencesStore.cpp
+++ b/src/app/PreferencesStore.cpp
@@ -281,6 +281,30 @@ void PreferencesStore::loadPreferences() {
     lastCompareLap_ =
         selection.value(QStringLiteral("compare_lap"), -1).toInt();
 
+    const QVariantMap event = config.map({QStringLiteral("event")});
+    eventMode_ = event.value(QStringLiteral("enabled"), false).toBool();
+    eventTrack_ = event.value(QStringLiteral("track")).toString();
+    eventSession_ = event.value(QStringLiteral("session")).toString();
+    eventDate_ = event.value(QStringLiteral("date")).toString();
+
+    const QVariantMap usb = config.map({QStringLiteral("usb")});
+    usbDest_ = usb.value(QStringLiteral("dest")).toString();
+    usbFormat_ =
+        usb.value(QStringLiteral("format"),
+                  QStringLiteral("{track}/{date}/{session}/{original}"))
+            .toString();
+    usbRenameScript_ = usb.value(QStringLiteral("rename_script")).toString();
+
+    const QVariantMap overlay = config.map({QStringLiteral("overlay")});
+    overlayRefColor_ =
+        overlay.value(QStringLiteral("ref_color"), QStringLiteral("#e09d7f"))
+            .toString();
+    overlayRefStyle_ =
+        overlay.value(QStringLiteral("ref_style"), QStringLiteral("dashed"))
+            .toString();
+    overlayRefWhite_ =
+        overlay.value(QStringLiteral("ref_white"), false).toBool();
+
     const QVariantMap mappings =
         config.map({QStringLiteral("driver_mappings")});
     for (auto it = mappings.cbegin(); it != mappings.cend(); ++it)
@@ -496,6 +520,20 @@ void PreferencesStore::scheduleSave() {
                     {QStringLiteral("primary_lap"), lastPrimaryLap_},
                     {QStringLiteral("compare_key"), lastCompareKey_},
                     {QStringLiteral("compare_lap"), lastCompareLap_}});
+    config.setMap({QStringLiteral("event")},
+                  QVariantMap{{QStringLiteral("enabled"), eventMode_},
+                              {QStringLiteral("track"), eventTrack_},
+                              {QStringLiteral("session"), eventSession_},
+                              {QStringLiteral("date"), eventDate_}});
+    config.setMap(
+        {QStringLiteral("usb")},
+        QVariantMap{{QStringLiteral("dest"), usbDest_},
+                    {QStringLiteral("format"), usbFormat_},
+                    {QStringLiteral("rename_script"), usbRenameScript_}});
+    config.setMap({QStringLiteral("overlay")},
+                  QVariantMap{{QStringLiteral("ref_color"), overlayRefColor_},
+                              {QStringLiteral("ref_style"), overlayRefStyle_},
+                              {QStringLiteral("ref_white"), overlayRefWhite_}});
 
     QVariantMap mappings;
     for (auto it = driverMappings_.cbegin(); it != driverMappings_.cend(); ++it)

--- a/src/app/PreferencesStore.h
+++ b/src/app/PreferencesStore.h
@@ -120,6 +120,31 @@ public:
     int lastCompareLap() const { return lastCompareLap_; }
     int& lastCompareLap() { return lastCompareLap_; }
 
+    bool eventMode() const { return eventMode_; }
+    void setEventMode(bool enabled) { eventMode_ = enabled; }
+    const QString& eventTrack() const { return eventTrack_; }
+    void setEventTrack(const QString& track) { eventTrack_ = track; }
+    const QString& eventSession() const { return eventSession_; }
+    void setEventSession(const QString& session) { eventSession_ = session; }
+    const QString& eventDate() const { return eventDate_; }
+    void setEventDate(const QString& date) { eventDate_ = date; }
+
+    const QString& usbDest() const { return usbDest_; }
+    void setUsbDest(const QString& dest) { usbDest_ = dest; }
+    const QString& usbFormat() const { return usbFormat_; }
+    void setUsbFormat(const QString& format) { usbFormat_ = format; }
+    const QString& usbRenameScript() const { return usbRenameScript_; }
+    void setUsbRenameScript(const QString& script) {
+        usbRenameScript_ = script;
+    }
+
+    const QString& overlayRefColor() const { return overlayRefColor_; }
+    void setOverlayRefColor(const QString& color) { overlayRefColor_ = color; }
+    const QString& overlayRefStyle() const { return overlayRefStyle_; }
+    void setOverlayRefStyle(const QString& style) { overlayRefStyle_ = style; }
+    bool overlayRefWhite() const { return overlayRefWhite_; }
+    void setOverlayRefWhite(bool enabled) { overlayRefWhite_ = enabled; }
+
 signals:
     void operationError(const QString& title, const QString& message);
 
@@ -146,4 +171,14 @@ private:
     QString lastCompareKey_;
     int lastPrimaryLap_ = -1;
     int lastCompareLap_ = -1;
+    bool eventMode_ = false;
+    QString eventTrack_;
+    QString eventSession_;
+    QString eventDate_;
+    QString usbDest_;
+    QString usbFormat_ = QStringLiteral("{track}/{date}/{session}/{original}");
+    QString usbRenameScript_;
+    QString overlayRefColor_ = QStringLiteral("#e09d7f");
+    QString overlayRefStyle_ = QStringLiteral("dashed");
+    bool overlayRefWhite_ = false;
 };

--- a/src/app/PreferencesWindow.qml
+++ b/src/app/PreferencesWindow.qml
@@ -162,6 +162,14 @@ ApplicationWindow {
                                 label: "Track data"
                             }
                             ListElement {
+                                detail: "Track and session"
+                                label: "Event"
+                            }
+                            ListElement {
+                                detail: "Reference HUD traces"
+                                label: "Overlay"
+                            }
+                            ListElement {
                                 detail: "GitHub AppImage"
                                 label: "Updates"
                             }
@@ -189,11 +197,17 @@ ApplicationWindow {
 
                 PreferencesLibraryPage {
                     id: libraryPage
+
                 }
                 PreferencesDriversPage {
                     id: driversPage
+
                 }
                 PreferencesTrackDataPage {
+                }
+                PreferencesEventPage {
+                }
+                PreferencesOverlayPage {
                 }
                 PreferencesUpdatesPage {
                 }

--- a/src/app/PreferencesWindow.qml
+++ b/src/app/PreferencesWindow.qml
@@ -1,13 +1,13 @@
 pragma ComponentBehavior: Bound
 import Omatrack
 
-// Modeless preferences workspace. Each section owns its domain state and
-// applies changes immediately; the shell only owns navigation.
-
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Material
 import QtQuick.Layouts
+
+// Modeless preferences workspace. Each section owns its domain state and
+// applies changes immediately; the shell only owns navigation.
 
 ApplicationWindow {
     id: preferencesWindow

--- a/src/app/PreferencesWindow.qml
+++ b/src/app/PreferencesWindow.qml
@@ -197,11 +197,9 @@ ApplicationWindow {
 
                 PreferencesLibraryPage {
                     id: libraryPage
-
                 }
                 PreferencesDriversPage {
                     id: driversPage
-
                 }
                 PreferencesTrackDataPage {
                 }

--- a/src/app/StoreModels.cpp
+++ b/src/app/StoreModels.cpp
@@ -1,10 +1,11 @@
 #include "StoreModels.h"
 
 #include <QString>
+#include <algorithm>
 
 // ── LapListModel ────────────────────────────────────────────────────
 
-LapListModel::LapListModel(QObject* parent) : QAbstractListModel(parent) {}
+LapListModel::LapListModel(QObject* parent) : IdentityListModel(parent) {}
 
 int LapListModel::rowCount(const QModelIndex& parent) const {
     return parent.isValid() ? 0 : rows_.size();
@@ -42,12 +43,20 @@ QHash<int, QByteArray> LapListModel::roleNames() const {
 }
 
 void LapListModel::refresh(const QVector<LapRow>& rows) {
-    beginResetModel();
-    rows_ = rows;
+    replaceByIdentity(
+        rows_, rows,
+        [](const LapRow& row) { return QString::number(row.lapId); },
+        [](const LapRow& a, const LapRow& b) {
+            return a.lapId == b.lapId && a.label == b.label &&
+                   a.timeText == b.timeText && a.timeMs == b.timeMs &&
+                   a.startTime == b.startTime && a.isFastest == b.isFastest &&
+                   a.isComplete == b.isComplete && a.isPitLap == b.isPitLap &&
+                   a.countsForBest == b.countsForBest;
+        });
     fixedLapCount_ = 0;
     flexibleTimeMs_ = 0;
     totalTimeMs_ = 0;
-    for (const LapRow& r : rows) {
+    for (const LapRow& r : rows_) {
         totalTimeMs_ += std::max(1, r.timeMs);
         if (!r.countsForBest)
             ++fixedLapCount_;
@@ -56,14 +65,13 @@ void LapListModel::refresh(const QVector<LapRow>& rows) {
     }
     flexibleTimeMs_ = std::max(1, flexibleTimeMs_);
     totalTimeMs_ = std::max(1, totalTimeMs_);
-    endResetModel();
     emit refreshed();
 }
 
 // ── ChannelListModel ────────────────────────────────────────────────
 
 ChannelListModel::ChannelListModel(QObject* parent)
-    : QAbstractListModel(parent) {}
+    : IdentityListModel(parent) {}
 
 int ChannelListModel::rowCount(const QModelIndex& parent) const {
     return parent.isValid() ? 0 : rows_.size();
@@ -101,15 +109,19 @@ QHash<int, QByteArray> ChannelListModel::roleNames() const {
 }
 
 void ChannelListModel::refresh(const QVector<ChannelRow>& rows) {
-    beginResetModel();
-    rows_ = rows;
-    endResetModel();
+    replaceByIdentity(
+        rows_, rows, [](const ChannelRow& row) { return row.key; },
+        [](const ChannelRow& a, const ChannelRow& b) {
+            return a.key == b.key && a.title == b.title && a.unit == b.unit &&
+                   a.visible == b.visible && a.color == b.color &&
+                   a.weight == b.weight && a.source == b.source &&
+                   a.sidecar == b.sidecar && a.span == b.span;
+        });
 }
 
 // ── CornerListModel ─────────────────────────────────────────────────
 
-CornerListModel::CornerListModel(QObject* parent)
-    : QAbstractListModel(parent) {}
+CornerListModel::CornerListModel(QObject* parent) : IdentityListModel(parent) {}
 
 int CornerListModel::rowCount(const QModelIndex& parent) const {
     return parent.isValid() ? 0 : rows_.size();
@@ -245,15 +257,24 @@ QHash<int, QByteArray> CornerListModel::roleNames() const {
 }
 
 void CornerListModel::refresh(const QVector<CornerRow>& rows) {
-    beginResetModel();
-    rows_ = rows;
-    endResetModel();
+    replaceByIdentity(
+        rows_, rows,
+        [](const CornerRow& row) {
+            return row.name + QChar(0) + QString::number(row.start, 'g', 12);
+        },
+        [](const CornerRow& a, const CornerRow& b) {
+            return a.name == b.name && a.start == b.start && a.end == b.end &&
+                   a.entrySpeed == b.entrySpeed && a.apexSpeed == b.apexSpeed &&
+                   a.exitSpeed == b.exitSpeed && a.time == b.time &&
+                   a.hasCompare == b.hasCompare && a.delta == b.delta &&
+                   a.note == b.note && a.score == b.score;
+        });
 }
 
 // ── DriverMappingModel ──────────────────────────────────────────────
 
 DriverMappingModel::DriverMappingModel(QObject* parent)
-    : QAbstractListModel(parent) {}
+    : IdentityListModel(parent) {}
 
 int DriverMappingModel::rowCount(const QModelIndex& parent) const {
     return parent.isValid() ? 0 : rows_.size();
@@ -281,21 +302,19 @@ QHash<int, QByteArray> DriverMappingModel::roleNames() const {
 }
 
 void DriverMappingModel::refresh(const QVector<DriverMappingRow>& rows) {
-    if (rows.size() == rows_.size()) {
-        rows_ = rows;
-        if (!rows_.isEmpty())
-            emit dataChanged(index(0), index(rows_.size() - 1));
-    } else {
-        beginResetModel();
-        rows_ = rows;
-        endResetModel();
-    }
+    replaceByIdentity(
+        rows_, rows, [](const DriverMappingRow& row) { return row.key; },
+        [](const DriverMappingRow& a, const DriverMappingRow& b) {
+            return a.key == b.key && a.carNumber == b.carNumber &&
+                   a.carClass == b.carClass && a.driverId == b.driverId &&
+                   a.display == b.display;
+        });
 }
 
 // ── SyncStrategyModel ───────────────────────────────────────────────
 
 SyncStrategyModel::SyncStrategyModel(QObject* parent)
-    : QAbstractListModel(parent) {}
+    : IdentityListModel(parent) {}
 
 int SyncStrategyModel::rowCount(const QModelIndex& parent) const {
     return parent.isValid() ? 0 : rows_.size();
@@ -323,9 +342,12 @@ QHash<int, QByteArray> SyncStrategyModel::roleNames() const {
 }
 
 void SyncStrategyModel::refresh(const QVector<SyncStrategyRow>& rows) {
-    beginResetModel();
-    rows_ = rows;
-    endResetModel();
+    replaceByIdentity(
+        rows_, rows, [](const SyncStrategyRow& row) { return row.id; },
+        [](const SyncStrategyRow& a, const SyncStrategyRow& b) {
+            return a.id == b.id && a.label == b.label &&
+                   a.shortLabel == b.shortLabel && a.detail == b.detail;
+        });
 }
 
 // ── RowFilterModel ──────────────────────────────────────────────────

--- a/src/app/StoreModels.cpp
+++ b/src/app/StoreModels.cpp
@@ -24,6 +24,7 @@ QVariant LapListModel::data(const QModelIndex& index, int role) const {
         case IsCompleteRole: return row.isComplete;
         case IsPitLapRole: return row.isPitLap;
         case CountsForBestRole: return row.countsForBest;
+        case HoverTextRole: return row.hoverText;
     }
     return {};
 }
@@ -39,6 +40,7 @@ QHash<int, QByteArray> LapListModel::roleNames() const {
         {IsCompleteRole, "isComplete"},
         {IsPitLapRole, "isPitLap"},
         {CountsForBestRole, "countsForBest"},
+        {HoverTextRole, "hoverText"},
     };
 }
 
@@ -51,7 +53,8 @@ void LapListModel::refresh(const QVector<LapRow>& rows) {
                    a.timeText == b.timeText && a.timeMs == b.timeMs &&
                    a.startTime == b.startTime && a.isFastest == b.isFastest &&
                    a.isComplete == b.isComplete && a.isPitLap == b.isPitLap &&
-                   a.countsForBest == b.countsForBest;
+                   a.countsForBest == b.countsForBest &&
+                   a.hoverText == b.hoverText;
         });
     fixedLapCount_ = 0;
     flexibleTimeMs_ = 0;
@@ -66,6 +69,59 @@ void LapListModel::refresh(const QVector<LapRow>& rows) {
     flexibleTimeMs_ = std::max(1, flexibleTimeMs_);
     totalTimeMs_ = std::max(1, totalTimeMs_);
     emit refreshed();
+}
+
+// ── FilmstripSessionListModel ───────────────────────────────────────
+
+FilmstripSessionListModel::FilmstripSessionListModel(QObject* parent)
+    : IdentityListModel(parent) {}
+
+int FilmstripSessionListModel::rowCount(const QModelIndex& parent) const {
+    return parent.isValid() ? 0 : rows_.size();
+}
+
+QVariant FilmstripSessionListModel::data(const QModelIndex& index,
+                                         int role) const {
+    if (!checkIndex(index, CheckIndexOption::IndexIsValid)) return {};
+    const FilmstripSessionRow& row = rows_[index.row()];
+    switch (role) {
+        case SessionKeyRole: return row.sessionKey;
+        case DriverNameRole: return row.driverName;
+        case BestTimeRole: return row.bestTime;
+        case ReferenceRole: return row.reference;
+    }
+    return {};
+}
+
+QHash<int, QByteArray> FilmstripSessionListModel::roleNames() const {
+    return {
+        {SessionKeyRole, "sessionKey"},
+        {DriverNameRole, "driverName"},
+        {BestTimeRole, "bestTime"},
+        {ReferenceRole, "reference"},
+    };
+}
+
+void FilmstripSessionListModel::refresh(
+    const QVector<FilmstripSessionRow>& rows) {
+    replaceByIdentity(
+        rows_, rows,
+        [](const FilmstripSessionRow& row) {
+            return row.reference ? QStringLiteral("reference")
+                                 : QStringLiteral("primary");
+        },
+        [](const FilmstripSessionRow& a, const FilmstripSessionRow& b) {
+            return a.sessionKey == b.sessionKey &&
+                   a.driverName == b.driverName && a.bestTime == b.bestTime &&
+                   a.reference == b.reference;
+        });
+    emit refreshed();
+}
+
+QString FilmstripSessionListModel::primarySessionKey() const {
+    for (const FilmstripSessionRow& row : rows_)
+        if (!row.reference) return row.sessionKey;
+    return {};
 }
 
 // ── ChannelListModel ────────────────────────────────────────────────

--- a/src/app/StoreModels.h
+++ b/src/app/StoreModels.h
@@ -11,16 +11,15 @@
 #pragma once
 
 #include "FilterChange.h"
+#include "ModelDiff.h"
 #include "StoreTypes.h"
-
-#include <QAbstractListModel>
 #include <QSortFilterProxyModel>
 #include <QVector>
 #include <QtQml/qqmlregistration.h>
 
 // ── lap list model ──────────────────────────────────────────────────
 
-class LapListModel : public QAbstractListModel {
+class LapListModel : public IdentityListModel {
     Q_OBJECT
     QML_ANONYMOUS
     Q_PROPERTY(int fixedLapCount READ fixedLapCount NOTIFY refreshed)
@@ -63,7 +62,7 @@ private:
 
 // ── channel list model ──────────────────────────────────────────────
 
-class ChannelListModel : public QAbstractListModel {
+class ChannelListModel : public IdentityListModel {
     Q_OBJECT
 public:
     enum Role {
@@ -93,7 +92,7 @@ private:
 
 // ── corner list model (basic ranges + comparison columns) ───────────
 
-class CornerListModel : public QAbstractListModel {
+class CornerListModel : public IdentityListModel {
     Q_OBJECT
 public:
     enum Role {
@@ -172,7 +171,7 @@ private:
 
 // ── driver mapping model ────────────────────────────────────────────
 
-class DriverMappingModel : public QAbstractListModel {
+class DriverMappingModel : public IdentityListModel {
     Q_OBJECT
 public:
     enum Role {
@@ -200,7 +199,7 @@ private:
 
 // ── sync strategy model ─────────────────────────────────────────────
 
-class SyncStrategyModel : public QAbstractListModel {
+class SyncStrategyModel : public IdentityListModel {
     Q_OBJECT
 public:
     enum Role {

--- a/src/app/StoreModels.h
+++ b/src/app/StoreModels.h
@@ -22,6 +22,7 @@
 class LapListModel : public IdentityListModel {
     Q_OBJECT
     QML_ANONYMOUS
+    Q_PROPERTY(int count READ count NOTIFY refreshed)
     Q_PROPERTY(int fixedLapCount READ fixedLapCount NOTIFY refreshed)
     Q_PROPERTY(int flexibleTimeMs READ flexibleTimeMs NOTIFY refreshed)
     Q_PROPERTY(int totalTimeMs READ totalTimeMs NOTIFY refreshed)
@@ -36,6 +37,7 @@ public:
         IsCompleteRole,
         IsPitLapRole,
         CountsForBestRole,
+        HoverTextRole,
     };
     Q_ENUM(Role)
 
@@ -46,6 +48,7 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     void refresh(const QVector<LapRow>& rows);
+    int count() const { return rows_.size(); }
     int fixedLapCount() const { return fixedLapCount_; }
     int flexibleTimeMs() const { return flexibleTimeMs_; }
     int totalTimeMs() const { return totalTimeMs_; }
@@ -58,6 +61,38 @@ private:
     int fixedLapCount_ = 0;
     int flexibleTimeMs_ = 0;
     int totalTimeMs_ = 0;
+};
+
+// ── filmstrip session model ─────────────────────────────────────────
+
+class FilmstripSessionListModel : public IdentityListModel {
+    Q_OBJECT
+    QML_ANONYMOUS
+    Q_PROPERTY(int count READ count NOTIFY refreshed)
+public:
+    enum Role {
+        SessionKeyRole = Qt::UserRole,
+        DriverNameRole,
+        BestTimeRole,
+        ReferenceRole,
+    };
+    Q_ENUM(Role)
+
+    explicit FilmstripSessionListModel(QObject* parent = nullptr);
+
+    int rowCount(const QModelIndex& parent = {}) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    void refresh(const QVector<FilmstripSessionRow>& rows);
+    int count() const { return rows_.size(); }
+    QString primarySessionKey() const;
+
+signals:
+    void refreshed();
+
+private:
+    QVector<FilmstripSessionRow> rows_;
 };
 
 // ── channel list model ──────────────────────────────────────────────

--- a/src/app/StoreTypes.h
+++ b/src/app/StoreTypes.h
@@ -26,6 +26,7 @@ class LapRow {
     Q_PROPERTY(bool isComplete MEMBER isComplete)
     Q_PROPERTY(bool isPitLap MEMBER isPitLap)
     Q_PROPERTY(bool countsForBest MEMBER countsForBest)
+    Q_PROPERTY(QString hoverText MEMBER hoverText)
 public:
     int lapId = 0;
     QString label;
@@ -36,6 +37,7 @@ public:
     bool isComplete = false;
     bool isPitLap = false;
     bool countsForBest = false;
+    QString hoverText;
 };
 
 // ── channel row ─────────────────────────────────────────────────────
@@ -443,6 +445,48 @@ public:
     QString bestLapText;
 };
 
+// ── filmstrip session row ───────────────────────────────────────────
+
+class FilmstripSessionRow {
+    Q_GADGET
+    QML_ANONYMOUS
+    Q_PROPERTY(QString sessionKey MEMBER sessionKey)
+    Q_PROPERTY(QString driverName MEMBER driverName)
+    Q_PROPERTY(QString bestTime MEMBER bestTime)
+    Q_PROPERTY(bool reference MEMBER reference)
+public:
+    QString sessionKey;
+    QString driverName;
+    QString bestTime;
+    bool reference = false;
+};
+
+// ── canonical active-session identity ───────────────────────────────
+// Video, traces, filmstrip, and sidebar must name the same session.
+
+class ActiveSessionRoles {
+    Q_GADGET
+    QML_VALUE_TYPE(activeSessionRoles)
+    Q_PROPERTY(QString sessionKey MEMBER sessionKey)
+    Q_PROPERTY(QString videoIdentity MEMBER videoIdentity)
+    Q_PROPERTY(QString filmstripKey MEMBER filmstripKey)
+    Q_PROPERTY(QString sidebarKey MEMBER sidebarKey)
+public:
+    QString sessionKey;
+    QString videoIdentity;
+    QString filmstripKey;
+    QString sidebarKey;
+
+    bool agree() const {
+        if (sessionKey != filmstripKey || sessionKey != sidebarKey)
+            return false;
+        if (!videoIdentity.isEmpty() && videoIdentity != sessionKey)
+            return false;
+        return true;
+    }
+};
+
 Q_DECLARE_METATYPE(CursorReadout)
 Q_DECLARE_METATYPE(CornerFocusSummary)
 Q_DECLARE_METATYPE(SessionInfoRow)
+Q_DECLARE_METATYPE(ActiveSessionRoles)

--- a/src/app/SwapRoles.h
+++ b/src/app/SwapRoles.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace omatrack {
+
+/// True when a primary/reference swap can proceed. The store no-ops when
+/// no reference session is set (hotkey X and the filmstrip menu).
+inline bool swapRolesPossible(bool hasReference) { return hasReference; }
+
+}  // namespace omatrack

--- a/src/app/TelemetryStore.cpp
+++ b/src/app/TelemetryStore.cpp
@@ -15,6 +15,11 @@
 #include "OverlayManager.h"
 #include "PreferencesStore.h"
 #include "TrackAtlasManager.h"
+#include "IndexCache.h"
+#include "LuaRename.h"
+#include "PathJail.h"
+#include "SwapRoles.h"
+#include "UsbMedia.h"
 
 #include <QCoreApplication>
 #include <QClipboard>
@@ -22,7 +27,9 @@
 #include <QDebug>
 #include <QDesktopServices>
 #include <QElapsedTimer>
+#include <QDate>
 #include <QDir>
+#include <QFileSystemWatcher>
 #include <QDirIterator>
 #include <QFile>
 #include <QFileInfo>
@@ -1798,6 +1805,16 @@ IndexedSession indexSession(const QString& path,
     }
 
     if (ioCancelled(cancel)) return {};
+    const QJsonObject cached = loadIndexCache(parserPath);
+    if (!cached.isEmpty()) {
+        auto cachedHandle =
+            std::make_unique<SessionHandle>(path, cached, parserPath);
+        if (cachedHandle->hasSummary()) {
+            IndexedSession result;
+            result.handle = std::move(cachedHandle);
+            return result;
+        }
+    }
     auto handle =
         std::make_unique<SessionHandle>(path, QJsonObject{}, parserPath);
     IndexedSession result;
@@ -1805,6 +1822,7 @@ IndexedSession indexSession(const QString& path,
         result.unsupportedVideo = isVideoPath(path);
         return result;
     }
+    storeIndexCache(parserPath, handle->metadataForCache());
     result.handle = std::move(handle);
     return result;
 }
@@ -2439,6 +2457,8 @@ TelemetryStore::TelemetryStore(QObject* parent)
     : QObject(parent),
       folderMetadataJob_(this),
       scanJob_(this),
+      usbScanJob_(this),
+      usbCopyJob_(this),
       fileOpenQueue_(this),
       primaryLapJob_(this),
       compareLapJob_(this),
@@ -2590,6 +2610,7 @@ TelemetryStore::TelemetryStore(QObject* parent)
     atlas_->startup();
 
     scan();
+    setupLibraryWatch();
 }
 
 TelemetryStore::~TelemetryStore() {
@@ -3588,7 +3609,9 @@ QVariantList TelemetryStore::buildFileSourceTree() const {
     };
 
     QVariantList sources;
-    sources.reserve(fileSources_.size() + 2);
+    sources.reserve(fileSources_.size() + usbFileSources_.size() + 2);
+    for (const QVariant& source : usbFileSources_)
+        sources.append(enrichNode(enrichNode, source.toMap()));
     for (const QVariant& source : fileSources_)
         sources.append(enrichNode(enrichNode, source.toMap()));
 
@@ -7686,4 +7709,428 @@ QStringList TelemetryStore::recentFiles() const {
 }
 const QVector<OverlayGroup>& TelemetryStore::overlayGroups() const {
     return overlays_->overlayGroups();
+}
+
+#include "IndexCache.h"
+#include "LuaRename.h"
+#include "PathJail.h"
+#include "SwapRoles.h"
+#include "UsbMedia.h"
+
+#include <QFileSystemWatcher>
+#include <QStorageInfo>
+
+namespace {
+
+QStringList usbWatchRoots() {
+    QStringList roots;
+    const QString user = QDir::home().dirName();
+    const QString runMedia = QStringLiteral("/run/media/") + user;
+    if (QFileInfo::exists(runMedia)) roots.append(runMedia);
+    if (QFileInfo::exists(QStringLiteral("/media")))
+        roots.append(QStringLiteral("/media"));
+    return roots;
+}
+
+QSet<QString> configuredFolderTargets(
+    const QVector<LibraryLocation>& locations) {
+    QSet<QString> targets;
+    for (const LibraryLocation& location : locations) {
+        if (location.type != LocationType::Folder) continue;
+        const QString absolute =
+            QDir::cleanPath(QFileInfo(location.target).absoluteFilePath());
+        if (!absolute.isEmpty()) targets.insert(absolute);
+    }
+    return targets;
+}
+
+QString usbSectionName(const UsbVolume& volume) {
+    return QStringLiteral("USB — %1").arg(volume.name);
+}
+
+std::shared_ptr<SessionScanResult> scanUsbVolumes(
+    const QVector<UsbVolume>& volumes, const QSet<QString>& skipRoots,
+    const IoCancel& cancel) {
+    auto result = std::make_shared<SessionScanResult>();
+    const QStringList filters{
+        "*.pds",       "*.PDS",  "*.ld",     "*.LD",  "*.vbo", "*.telemetry",
+        "*.TELEMETRY", "*.VBO",  "*.mp4",    "*.MP4", "*.mov", "*.MOV",
+        "*.mkv",       "*.MKV",  "*.avi",    "*.AVI", "*.m4v", "*.M4V",
+        "*.webm",      "*.WEBM", "TRACK.yml"};
+    for (const UsbVolume& volume : volumes) {
+        if (ioCancelled(cancel)) break;
+        if (skipRoots.contains(volume.rootPath)) continue;
+        QSet<QString> sourcePaths;
+        QDirIterator it(volume.rootPath, filters, QDir::Files,
+                        QDirIterator::Subdirectories);
+        while (it.hasNext()) {
+            it.next();
+            if (it.fileName() == QStringLiteral("TRACK.yml")) continue;
+            const QString path = vendorSourcePath(it.filePath());
+            if (path.isEmpty()) continue;
+            if (isSidecarPath(QDir(volume.rootPath).relativeFilePath(path)))
+                continue;
+            const QFileInfo resolved(path);
+            const QString canonical = resolved.canonicalFilePath().isEmpty()
+                                          ? resolved.absoluteFilePath()
+                                          : resolved.canonicalFilePath();
+            sourcePaths.insert(canonical);
+        }
+        if (sourcePaths.isEmpty()) continue;
+        QVariantMap source = buildFileSource(volume.rootPath, sourcePaths);
+        source.insert(QStringLiteral("name"), usbSectionName(volume));
+        source.insert(QStringLiteral("transient"), true);
+        source.insert(QStringLiteral("usb"), true);
+        result->fileSources.append(source);
+        result->locationFileCounts.insert(volume.rootPath, sourcePaths.size());
+    }
+    return result;
+}
+
+QVariantMap copyContext(const QString& path, const QString& track,
+                        const QString& date, const QString& session,
+                        const QString& driver) {
+    const QFileInfo info(path);
+    return QVariantMap{
+        {QStringLiteral("track"),
+         track.isEmpty() ? QStringLiteral("unknown") : track},
+        {QStringLiteral("date"),
+         date.isEmpty() ? QDate::currentDate().toString(Qt::ISODate) : date},
+        {QStringLiteral("session"),
+         session.isEmpty() ? QStringLiteral("session") : session},
+        {QStringLiteral("original"), info.fileName()},
+        {QStringLiteral("driver"), driver},
+        {QStringLiteral("stem"), info.completeBaseName()},
+        {QStringLiteral("ext"), info.suffix()},
+    };
+}
+
+}  // namespace
+
+void TelemetryStore::setupLibraryWatch() {
+    libraryWatch_ = new QFileSystemWatcher(this);
+    usbPollTimer_ = new QTimer(this);
+    usbPollTimer_->setInterval(3000);
+    usbDebounce_ = new QTimer(this);
+    usbDebounce_->setSingleShot(true);
+    usbDebounce_->setInterval(400);
+    connect(usbDebounce_, &QTimer::timeout, this, [this]() {
+        if (usbRescanOnly_)
+            startUsbScan();
+        else
+            scan();
+        usbRescanOnly_ = false;
+    });
+    connect(libraryWatch_, &QFileSystemWatcher::directoryChanged, this,
+            [this](const QString& path) {
+                const QString slash = QDir::fromNativeSeparators(path);
+                usbRescanOnly_ =
+                    slash.startsWith(QStringLiteral("/run/media/")) ||
+                    slash.startsWith(QStringLiteral("/media/"));
+                usbDebounce_->start();
+            });
+    connect(usbPollTimer_, &QTimer::timeout, this, [this]() {
+        const auto volumes = mountedUsbVolumes();
+        QStringList roots;
+        for (const UsbVolume& volume : volumes) roots.append(volume.rootPath);
+        if (roots == usbRoots_) return;
+        usbRoots_ = roots;
+        usbRescanOnly_ = true;
+        usbDebounce_->start();
+    });
+    rebuildLibraryWatch();
+    usbPollTimer_->start();
+    startUsbScan();
+}
+
+void TelemetryStore::rebuildLibraryWatch() {
+    if (!libraryWatch_) return;
+    const QStringList current = libraryWatch_->directories();
+    if (!current.isEmpty()) libraryWatch_->removePaths(current);
+    QStringList paths;
+    for (const LibraryLocation& location : prefs_->locations()) {
+        if (!location.enabled || location.type != LocationType::Folder)
+            continue;
+        if (QFileInfo(location.target).isDir()) paths.append(location.target);
+    }
+    paths += usbWatchRoots();
+    paths += usbRoots_;
+    paths.removeDuplicates();
+    if (!paths.isEmpty()) libraryWatch_->addPaths(paths);
+}
+
+void TelemetryStore::startUsbScan() {
+    const QVector<UsbVolume> volumes = mountedUsbVolumes();
+    const QSet<QString> skip = configuredFolderTargets(prefs_->locations());
+    usbScanJob_.start(
+        [volumes, skip](IoCancel cancel) {
+            return scanUsbVolumes(volumes, skip, cancel);
+        },
+        [this](std::shared_ptr<SessionScanResult> result) {
+            finishUsbScan(std::move(result));
+        });
+}
+
+void TelemetryStore::finishUsbScan(std::shared_ptr<SessionScanResult> result) {
+    usbFileSources_.clear();
+    usbPresent_ = false;
+    usbLabel_.clear();
+    if (result) {
+        usbFileSources_ = result->fileSources;
+        usbPresent_ = !usbFileSources_.isEmpty();
+        if (usbPresent_)
+            usbLabel_ = usbFileSources_.constFirst()
+                            .toMap()
+                            .value(QStringLiteral("name"))
+                            .toString();
+    }
+    rebuildLibraryWatch();
+    refreshLibraryModel();
+    emit usbChanged();
+}
+
+bool TelemetryStore::eventMode() const { return prefs_->eventMode(); }
+QString TelemetryStore::eventTrack() const { return prefs_->eventTrack(); }
+QString TelemetryStore::eventSession() const { return prefs_->eventSession(); }
+QString TelemetryStore::eventDate() const { return prefs_->eventDate(); }
+
+void TelemetryStore::setEventMode(bool enabled) {
+    if (prefs_->eventMode() == enabled) return;
+    prefs_->setEventMode(enabled);
+    if (enabled) {
+        if (prefs_->eventDate().isEmpty())
+            prefs_->setEventDate(QDate::currentDate().toString(Qt::ISODate));
+        if (prefs_->eventTrack().isEmpty() && primarySession_) {
+            const QString track = displayTrack(primarySession_);
+            if (!track.isEmpty()) prefs_->setEventTrack(track);
+        }
+    }
+    schedulePreferencesSave();
+    emit eventChanged();
+}
+
+void TelemetryStore::setEventTrack(const QString& track) {
+    if (prefs_->eventTrack() == track) return;
+    prefs_->setEventTrack(track);
+    schedulePreferencesSave();
+    emit eventChanged();
+}
+
+void TelemetryStore::setEventSession(const QString& session) {
+    if (prefs_->eventSession() == session) return;
+    prefs_->setEventSession(session.trimmed());
+    schedulePreferencesSave();
+    emit eventChanged();
+}
+
+void TelemetryStore::setEventDate(const QString& date) {
+    if (prefs_->eventDate() == date) return;
+    prefs_->setEventDate(date);
+    schedulePreferencesSave();
+    emit eventChanged();
+}
+
+QString TelemetryStore::usbDest() const { return prefs_->usbDest(); }
+QString TelemetryStore::usbFormat() const { return prefs_->usbFormat(); }
+QString TelemetryStore::usbRenameScript() const {
+    return prefs_->usbRenameScript();
+}
+
+void TelemetryStore::setUsbDest(const QString& dest) {
+    if (prefs_->usbDest() == dest) return;
+    prefs_->setUsbDest(dest);
+    schedulePreferencesSave();
+    emit usbChanged();
+}
+
+void TelemetryStore::setUsbFormat(const QString& format) {
+    if (prefs_->usbFormat() == format) return;
+    prefs_->setUsbFormat(format);
+    schedulePreferencesSave();
+    emit usbChanged();
+}
+
+void TelemetryStore::setUsbRenameScript(const QString& script) {
+    if (prefs_->usbRenameScript() == script) return;
+    prefs_->setUsbRenameScript(script);
+    schedulePreferencesSave();
+    emit usbChanged();
+}
+
+QString TelemetryStore::luaRenameExample() const {
+    return exampleLuaRenameScript();
+}
+
+void TelemetryStore::showUsbCopy() {
+    if (!usbPresent_) return;
+    usbCopyVisible_ = true;
+    emit usbChanged();
+}
+
+void TelemetryStore::hideUsbCopy() {
+    if (!usbCopyVisible_) return;
+    usbCopyVisible_ = false;
+    emit usbChanged();
+}
+
+void TelemetryStore::copyUsbFiles() {
+    if (usbCopyJob_.running() || usbFileSources_.isEmpty()) return;
+    const QString dest = prefs_->usbDest().trimmed().isEmpty()
+                             ? defaultTelemetryDirectory()
+                             : prefs_->usbDest().trimmed();
+    const QString format = prefs_->usbFormat().trimmed().isEmpty()
+                               ? defaultCopyFormat()
+                               : prefs_->usbFormat();
+    const QString script = prefs_->usbRenameScript();
+    const QString track = prefs_->eventTrack();
+    const QString session = prefs_->eventSession();
+    const QString date = prefs_->eventDate().isEmpty()
+                             ? QDate::currentDate().toString(Qt::ISODate)
+                             : prefs_->eventDate();
+    QStringList files;
+    const auto collect = [&](auto&& self, const QVariantList& nodes) -> void {
+        for (const QVariant& node : nodes) {
+            const QVariantMap map = node.toMap();
+            if (map.value(QStringLiteral("role")).toString() ==
+                QStringLiteral("file")) {
+                const QString path =
+                    map.value(QStringLiteral("path")).toString();
+                if (!path.isEmpty()) files.append(path);
+            }
+            self(self, map.value(QStringLiteral("children")).toList());
+        }
+    };
+    collect(collect, usbFileSources_);
+    usbCopyStatus_ = QStringLiteral("Copying…");
+    usbCopyProgress_ = 0.0;
+    emit usbChanged();
+    usbCopyJob_.start(
+        [dest, format, script, track, session, date, files](IoCancel cancel) {
+            QString error;
+            int copied = 0;
+            for (int i = 0; i < files.size(); ++i) {
+                if (ioCancelled(cancel)) {
+                    error = QStringLiteral("Cancelled");
+                    break;
+                }
+                const QString source = files.at(i);
+                QVariantMap ctx = copyContext(source, track, date, session, {});
+                QString relative = expandCopyFormat(format, ctx);
+                if (!script.trimmed().isEmpty()) {
+                    const LuaRenameResult lua = runLuaRename(script, ctx);
+                    if (!lua.ok) {
+                        error = lua.error;
+                        break;
+                    }
+                    if (!lua.relativePath.trimmed().isEmpty())
+                        relative = lua.relativePath;
+                }
+                const PathJailResult jailed = jailRelativePath(dest, relative);
+                if (!jailed.ok) {
+                    error = jailed.error;
+                    break;
+                }
+                QDir().mkpath(QFileInfo(jailed.absolutePath).absolutePath());
+                if (QFileInfo::exists(jailed.absolutePath)) {
+                    ++copied;
+                    continue;
+                }
+                if (!QFile::copy(source, jailed.absolutePath)) {
+                    error = QStringLiteral("Could not copy %1")
+                                .arg(QFileInfo(source).fileName());
+                    break;
+                }
+                ++copied;
+            }
+            return QVariantMap{{QStringLiteral("error"), error},
+                               {QStringLiteral("copied"), copied},
+                               {QStringLiteral("dest"), dest}};
+        },
+        [this](QVariantMap result) {
+            const QString error =
+                result.value(QStringLiteral("error")).toString();
+            usbCopyProgress_ = 1.0;
+            if (!error.isEmpty()) {
+                usbCopyStatus_ = error;
+                emit operationError(QStringLiteral("USB copy"), error);
+            } else {
+                usbCopyStatus_ =
+                    QStringLiteral("Copied %1 files")
+                        .arg(result.value(QStringLiteral("copied")).toInt());
+                usbCopyVisible_ = false;
+                const QString dest =
+                    result.value(QStringLiteral("dest")).toString();
+                if (!dest.isEmpty()) appendFolderLocation(dest, false);
+                scan();
+            }
+            emit usbChanged();
+        });
+}
+
+bool TelemetryStore::swapPrimaryWithReference() {
+    if (!omatrack::swapRolesPossible(compareSession_ != nullptr)) return false;
+    SessionHandle* primary = primarySession_;
+    SessionHandle* compare = compareSession_;
+    const int primaryLap = primaryLap_;
+    const int compareLap = compareLap_;
+    primarySession_ = compare;
+    primaryLap_ = compareLap;
+    compareSession_ = primary;
+    compareLap_ = primaryLap;
+    overlays_->setPrimarySession(primarySession_);
+    overlays_->setPrimaryLap(primaryLap_);
+    overlays_->setCompareSession(compareSession_);
+    overlays_->setEventLabel(primaryLabel());
+    overlays_->setDriverName(primaryDriverName());
+    deltaCacheValid_ = false;
+    damperAlignmentValid_ = false;
+    invalidateComparisonAlignment();
+    rebuildComparisonAlignment();
+    prefs_->lastPrimaryKey() =
+        primarySession_ ? primarySession_->sessionKey() : QString();
+    prefs_->lastPrimaryLap() = primaryLap_;
+    prefs_->lastCompareKey() =
+        compareSession_ ? compareSession_->sessionKey() : QString();
+    prefs_->lastCompareLap() = compareLap_;
+    schedulePreferencesSave();
+    loadCornersForPrimary();
+    overlays_->resampleOverlays();
+    emit cornersChanged();
+    emit videoTimeChanged();
+    emit selectionChanged();
+    emit cursorFracChanged();
+    refreshLapModels();
+    libraryModel_->updateSelection(primarySessionKey(), compareSessionKey());
+    return true;
+}
+
+QString TelemetryStore::overlayRefColor() const {
+    return prefs_->overlayRefColor();
+}
+QString TelemetryStore::overlayRefStyle() const {
+    return prefs_->overlayRefStyle();
+}
+bool TelemetryStore::overlayRefWhite() const {
+    return prefs_->overlayRefWhite();
+}
+
+void TelemetryStore::setOverlayRefColor(const QString& color) {
+    if (prefs_->overlayRefColor() == color) return;
+    prefs_->setOverlayRefColor(color);
+    schedulePreferencesSave();
+    emit overlayStyleChanged();
+}
+
+void TelemetryStore::setOverlayRefStyle(const QString& style) {
+    if (prefs_->overlayRefStyle() == style) return;
+    prefs_->setOverlayRefStyle(style);
+    schedulePreferencesSave();
+    emit overlayStyleChanged();
+}
+
+void TelemetryStore::setOverlayRefWhite(bool enabled) {
+    if (prefs_->overlayRefWhite() == enabled) return;
+    prefs_->setOverlayRefWhite(enabled);
+    schedulePreferencesSave();
+    emit overlayStyleChanged();
 }

--- a/src/app/TelemetryStore.cpp
+++ b/src/app/TelemetryStore.cpp
@@ -2559,6 +2559,7 @@ TelemetryStore::TelemetryStore(QObject* parent)
     // refreshes them; refreshed on the matching store signal.
     primaryLapsModel_ = std::make_unique<LapListModel>(this);
     compareLapsModel_ = std::make_unique<LapListModel>(this);
+    filmstripSessionsModel_ = std::make_unique<FilmstripSessionListModel>(this);
     channelsModel_ = std::make_unique<ChannelListModel>(this);
     cornersModel_ = std::make_unique<CornerListModel>(this);
     driverMappingsModel_ = std::make_unique<DriverMappingModel>(this);
@@ -2566,6 +2567,7 @@ TelemetryStore::TelemetryStore(QObject* parent)
     libraryModel_ = std::make_unique<LibraryModel>(this);
     connect(this, &TelemetryStore::selectionChanged, this, [this]() {
         refreshLapModels();
+        refreshFilmstripModel();
         refreshCornersModel();
         refreshSyncStrategyModel();
     });
@@ -2573,6 +2575,7 @@ TelemetryStore::TelemetryStore(QObject* parent)
         refreshLibraryModel();
         refreshDriverMappingsModel();
         refreshLapModels();
+        refreshFilmstripModel();
     });
     connect(this, &TelemetryStore::channelConfigChanged, this,
             [this]() { refreshChannelsModel(); });
@@ -5012,6 +5015,8 @@ void TelemetryStore::setPrimary(SessionHandle* session, int lapId) {
     overlays_->resampleOverlays();
     emit cornersChanged();
     emit videoTimeChanged();
+    emit cursorFracChanged();
+    emit selectionChanged();
     logSelectedLap("select primary", session, lapId);
 }
 
@@ -5194,20 +5199,62 @@ int TelemetryStore::bestLapIdForSession(const QString& sessionKey) const {
     return s->laps().first().lapId;
 }
 
+namespace {
+QString formatLapDeltaMs(double deltaMs) {
+    const double seconds = deltaMs / 1000.0;
+    const QString sign =
+        seconds >= 0.0 ? QStringLiteral("+") : QStringLiteral("−");
+    return sign + QString::number(std::fabs(seconds), 'f', 3);
+}
+
+QString lapHoverText(const QVector<LapEntry>& laps, const LapEntry& target,
+                     int selectedLapId) {
+    QStringList parts;
+    parts.append(target.timeText);
+    const LapEntry* best = nullptr;
+    const LapEntry* selected = nullptr;
+    for (const LapEntry& lap : laps) {
+        if (lap.countsForBest() && (!best || lap.timeMs < best->timeMs))
+            best = &lap;
+        if (lap.lapId == selectedLapId) selected = &lap;
+    }
+    if (best && best->lapId != target.lapId)
+        parts.append(QStringLiteral("vs best %1")
+                         .arg(formatLapDeltaMs(target.timeMs - best->timeMs)));
+    if (selected && selected->lapId != target.lapId &&
+        (!best || selected->lapId != best->lapId))
+        parts.append(
+            QStringLiteral("vs sel %1")
+                .arg(formatLapDeltaMs(target.timeMs - selected->timeMs)));
+    for (const LapEntry& lap : laps) {
+        if (!lap.countsForBest() || lap.lapId == target.lapId) continue;
+        if (best && lap.lapId == best->lapId) continue;
+        if (selected && lap.lapId == selected->lapId) continue;
+        parts.append(QStringLiteral("%1 %2").arg(
+            lap.label, formatLapDeltaMs(target.timeMs - lap.timeMs)));
+    }
+    return parts.join(QStringLiteral("  "));
+}
+}  // namespace
+
 QVector<LapRow> TelemetryStore::buildLapRows(SessionHandle* session) const {
     QVector<LapRow> rows;
     if (!session) return rows;
+    const int selectedId = session == primarySession_   ? primaryLap_
+                           : session == compareSession_ ? compareLap_
+                                                        : -1;
     for (const LapEntry& l : session->laps()) {
         LapRow row;
         row.lapId = l.lapId;
         row.label = l.label;
         row.timeText = l.timeText;
-        row.timeMs = l.timeMs;
+        row.timeMs = int(l.timeMs);
         row.startTime = l.startTime;
         row.isFastest = l.isFastest;
         row.isComplete = l.isComplete;
         row.isPitLap = l.isPitLap;
         row.countsForBest = l.countsForBest();
+        row.hoverText = lapHoverText(session->laps(), l, selectedId);
         rows.append(row);
     }
     return rows;
@@ -5221,6 +5268,40 @@ QVector<LapRow> TelemetryStore::lapRowsForSession(
 void TelemetryStore::refreshLapModels() {
     primaryLapsModel_->refresh(buildLapRows(primarySession_));
     compareLapsModel_->refresh(buildLapRows(compareSession_));
+}
+
+void TelemetryStore::refreshFilmstripModel() {
+    QVector<FilmstripSessionRow> rows;
+    if (primarySession_) {
+        FilmstripSessionRow row;
+        row.sessionKey = primarySession_->sessionKey();
+        row.driverName = driverDisplay(primarySession_);
+        row.bestTime = primarySession_->bestLapTime();
+        row.reference = false;
+        rows.append(row);
+    }
+    if (compareSession_ && compareSession_ != primarySession_) {
+        FilmstripSessionRow row;
+        row.sessionKey = compareSession_->sessionKey();
+        row.driverName = driverDisplay(compareSession_);
+        row.bestTime = compareSession_->bestLapTime();
+        row.reference = true;
+        rows.append(row);
+    }
+    filmstripSessionsModel_->refresh(rows);
+}
+
+ActiveSessionRoles TelemetryStore::activeSessionRoles() const {
+    ActiveSessionRoles roles;
+    roles.sessionKey = primarySessionKey();
+    if (primarySession_ && primarySession_->isVideo())
+        roles.videoIdentity = primarySession_->path();
+    roles.filmstripKey = filmstripSessionsModel_
+                             ? filmstripSessionsModel_->primarySessionKey()
+                             : QString();
+    roles.sidebarKey =
+        libraryModel_ ? libraryModel_->primarySessionKey() : QString();
+    return roles;
 }
 bool TelemetryStore::traceConfidenceIncludesLap(const QString& sessionKey,
                                                 int lapId) const {

--- a/src/app/TelemetryStore.h
+++ b/src/app/TelemetryStore.h
@@ -42,6 +42,7 @@ class SessionHandle;
 class TelemetryStore;
 class QNetworkAccessManager;
 class QTimer;
+class QFileSystemWatcher;
 class QQmlEngine;
 class QJSEngine;
 template <typename T>
@@ -465,6 +466,30 @@ class TelemetryStore : public QObject {
                    videoMutedChanged)
     Q_PROPERTY(
         QStringList recentFiles READ recentFiles NOTIFY recentFilesChanged)
+    Q_PROPERTY(
+        bool eventMode READ eventMode WRITE setEventMode NOTIFY eventChanged)
+    Q_PROPERTY(QString eventTrack READ eventTrack WRITE setEventTrack NOTIFY
+                   eventChanged)
+    Q_PROPERTY(QString eventSession READ eventSession WRITE setEventSession
+                   NOTIFY eventChanged)
+    Q_PROPERTY(
+        QString eventDate READ eventDate WRITE setEventDate NOTIFY eventChanged)
+    Q_PROPERTY(bool usbPresent READ usbPresent NOTIFY usbChanged)
+    Q_PROPERTY(QString usbLabel READ usbLabel NOTIFY usbChanged)
+    Q_PROPERTY(bool usbCopyVisible READ usbCopyVisible NOTIFY usbChanged)
+    Q_PROPERTY(QString usbCopyStatus READ usbCopyStatus NOTIFY usbChanged)
+    Q_PROPERTY(double usbCopyProgress READ usbCopyProgress NOTIFY usbChanged)
+    Q_PROPERTY(QString usbDest READ usbDest WRITE setUsbDest NOTIFY usbChanged)
+    Q_PROPERTY(
+        QString usbFormat READ usbFormat WRITE setUsbFormat NOTIFY usbChanged)
+    Q_PROPERTY(QString usbRenameScript READ usbRenameScript WRITE
+                   setUsbRenameScript NOTIFY usbChanged)
+    Q_PROPERTY(QString overlayRefColor READ overlayRefColor WRITE
+                   setOverlayRefColor NOTIFY overlayStyleChanged)
+    Q_PROPERTY(QString overlayRefStyle READ overlayRefStyle WRITE
+                   setOverlayRefStyle NOTIFY overlayStyleChanged)
+    Q_PROPERTY(bool overlayRefWhite READ overlayRefWhite WRITE
+                   setOverlayRefWhite NOTIFY overlayStyleChanged)
 public:
     // Registered as the `Store` singleton of the Omatrack QML module. The
     // QML engine owns the single instance and default-constructs it while
@@ -479,6 +504,35 @@ public:
     Q_INVOKABLE void closeTrack(const QString& trackName);
 
     Q_INVOKABLE void scan();
+    bool eventMode() const;
+    QString eventTrack() const;
+    QString eventSession() const;
+    QString eventDate() const;
+    Q_INVOKABLE void setEventMode(bool enabled);
+    Q_INVOKABLE void setEventTrack(const QString& track);
+    Q_INVOKABLE void setEventSession(const QString& session);
+    Q_INVOKABLE void setEventDate(const QString& date);
+    bool usbPresent() const { return usbPresent_; }
+    QString usbLabel() const { return usbLabel_; }
+    bool usbCopyVisible() const { return usbCopyVisible_; }
+    QString usbCopyStatus() const { return usbCopyStatus_; }
+    double usbCopyProgress() const { return usbCopyProgress_; }
+    QString usbDest() const;
+    QString usbFormat() const;
+    QString usbRenameScript() const;
+    Q_INVOKABLE void setUsbDest(const QString& dest);
+    Q_INVOKABLE void setUsbFormat(const QString& format);
+    Q_INVOKABLE void setUsbRenameScript(const QString& script);
+    Q_INVOKABLE void showUsbCopy();
+    Q_INVOKABLE void hideUsbCopy();
+    Q_INVOKABLE void copyUsbFiles();
+    Q_INVOKABLE QString luaRenameExample() const;
+    QString overlayRefColor() const;
+    QString overlayRefStyle() const;
+    bool overlayRefWhite() const;
+    Q_INVOKABLE void setOverlayRefColor(const QString& color);
+    Q_INVOKABLE void setOverlayRefStyle(const QString& style);
+    Q_INVOKABLE void setOverlayRefWhite(bool enabled);
     Q_INVOKABLE void addSessionDirectory(const QString& dirPath);
     /// Queue one telemetry source for indexing and lap loading. Ordinary video
     /// is reported through standaloneVideoRequested after background probing.
@@ -604,6 +658,8 @@ public:
     Q_INVOKABLE void compareLap(const QString& sessionKey, int lapId);
     Q_INVOKABLE void clearCompare();
     Q_INVOKABLE void clearPrimary();
+    /// Swap primary and reference analysis roles. No-op without a reference.
+    Q_INVOKABLE bool swapPrimaryWithReference();
     /// Next lap in recording order after the primary, or -1 at the last lap.
     Q_INVOKABLE int nextPrimaryLapId() const;
     Q_INVOKABLE QString lapLabel(const QString& sessionKey, int lapId) const;
@@ -843,6 +899,9 @@ signals:
     void sidebarMetadataChanged(const QString& path,
                                 const QVariantMap& details);
     void recentFilesChanged();
+    void eventChanged();
+    void usbChanged();
+    void overlayStyleChanged();
     void standaloneVideoRequested(const QUrl& source);
     void operationError(const QString& title, const QString& message);
     void overlaysChanged();
@@ -882,6 +941,10 @@ private:
     void setCompareLapLoading(bool loading);
     void startSessionScan();
     void finishSessionScan(std::shared_ptr<SessionScanResult> result);
+    void setupLibraryWatch();
+    void rebuildLibraryWatch();
+    void startUsbScan();
+    void finishUsbScan(std::shared_ptr<SessionScanResult> result);
     int sidebarPinIndex(const QString& kind, const QString& path) const;
     void rememberRecentFile(const QString& filePath);
     QString driverDisplay(const SessionHandle* session) const;
@@ -952,6 +1015,8 @@ private:
     /// through operationError.
     AsyncJob<FolderMetadataWrite> folderMetadataJob_;
     AsyncJob<std::shared_ptr<SessionScanResult>> scanJob_;
+    AsyncJob<std::shared_ptr<SessionScanResult>> usbScanJob_;
+    AsyncJob<QVariantMap> usbCopyJob_;
     SerialJobQueue<std::shared_ptr<FileOpenResult>> fileOpenQueue_;
     QString fileOpenPath_;
     QSet<QString> transientSessionPaths_;
@@ -1051,4 +1116,15 @@ private:
     std::unique_ptr<DriverMappingModel> driverMappingsModel_;
     std::unique_ptr<SyncStrategyModel> syncStrategyModel_;
     std::unique_ptr<LibraryModel> libraryModel_;
+    QFileSystemWatcher* libraryWatch_ = nullptr;
+    QTimer* usbPollTimer_ = nullptr;
+    QTimer* usbDebounce_ = nullptr;
+    QStringList usbRoots_;
+    QVariantList usbFileSources_;
+    bool usbPresent_ = false;
+    bool usbCopyVisible_ = false;
+    bool usbRescanOnly_ = false;
+    QString usbLabel_;
+    QString usbCopyStatus_;
+    double usbCopyProgress_ = 0.0;
 };

--- a/src/app/TelemetryStore.h
+++ b/src/app/TelemetryStore.h
@@ -455,6 +455,8 @@ class TelemetryStore : public QObject {
         LapListModel* primaryLaps READ primaryLapsModel NOTIFY selectionChanged)
     Q_PROPERTY(
         LapListModel* compareLaps READ compareLapsModel NOTIFY selectionChanged)
+    Q_PROPERTY(FilmstripSessionListModel* filmstripSessions READ
+                   filmstripSessionsModel NOTIFY selectionChanged)
     Q_PROPERTY(QAbstractItemModel* channels READ channelsModel NOTIFY
                    channelConfigChanged)
     Q_PROPERTY(
@@ -667,6 +669,7 @@ public:
     /// Load a lap into the session cache without changing the selection.
     Q_INVOKABLE void prefetchLap(const QString& sessionKey, int lapId);
     Q_INVOKABLE int bestLapIdForSession(const QString& sessionKey) const;
+    Q_INVOKABLE ActiveSessionRoles activeSessionRoles() const;
     QVector<LapRow> lapRowsForSession(const QString& sessionKey) const;
     Q_INVOKABLE bool traceConfidenceIncludesLap(const QString& sessionKey,
                                                 int lapId) const;
@@ -853,6 +856,9 @@ public:
     }
     LapListModel* primaryLapsModel() const { return primaryLapsModel_.get(); }
     LapListModel* compareLapsModel() const { return compareLapsModel_.get(); }
+    FilmstripSessionListModel* filmstripSessionsModel() const {
+        return filmstripSessionsModel_.get();
+    }
     QAbstractItemModel* channelsModel() const { return channelsModel_.get(); }
     QAbstractItemModel* cornersModel() const { return cornersModel_.get(); }
     QAbstractItemModel* driverMappingsModel() const {
@@ -986,6 +992,7 @@ private:
     double nextCornerStartFraction() const;
     // ── typed model refresh ────────────────────────────────────────
     void refreshLapModels();
+    void refreshFilmstripModel();
     void refreshChannelsModel();
     void refreshCornersModel();
     void refreshDriverMappingsModel();
@@ -1111,6 +1118,7 @@ private:
     // builders. Owned by the store; refreshed on the matching store signal.
     std::unique_ptr<LapListModel> primaryLapsModel_;
     std::unique_ptr<LapListModel> compareLapsModel_;
+    std::unique_ptr<FilmstripSessionListModel> filmstripSessionsModel_;
     std::unique_ptr<ChannelListModel> channelsModel_;
     std::unique_ptr<CornerListModel> cornersModel_;
     std::unique_ptr<DriverMappingModel> driverMappingsModel_;

--- a/src/app/TraceSceneBuilder.cpp
+++ b/src/app/TraceSceneBuilder.cpp
@@ -276,7 +276,20 @@ void TraceSceneBuilder::envelopePolyline(
         // Polyline through interpolated sample points, one per device column.
         pointsScratch_.clear();
         pointsScratch_.reserve(columns);
+        const int dashOn = style.dash == EnvelopeStyle::Dash::Dotted   ? 2
+                           : style.dash == EnvelopeStyle::Dash::Dashed ? 6
+                                                                       : 0;
+        const int dashOff = style.dash == EnvelopeStyle::Dash::Dotted   ? 4
+                            : style.dash == EnvelopeStyle::Dash::Dashed ? 4
+                                                                        : 0;
         for (int column = 0; column < columns; ++column) {
+            if (dashOn > 0) {
+                const int period = dashOn + dashOff;
+                if ((column % period) >= dashOn) {
+                    flush(pointsScratch_);
+                    continue;
+                }
+            }
             const double fraction =
                 xStart + xSpan * (double(column) + 0.5) / double(columns);
             if (fraction < clipLow || fraction > clipHigh) {
@@ -308,7 +321,20 @@ void TraceSceneBuilder::envelopePolyline(
     bool hasPrevious = false;
     double previousTop = 0.0;
     double previousBottom = 0.0;
+    const int envDashOn = style.dash == EnvelopeStyle::Dash::Dotted   ? 2
+                          : style.dash == EnvelopeStyle::Dash::Dashed ? 6
+                                                                      : 0;
+    const int envDashOff = style.dash == EnvelopeStyle::Dash::Dotted   ? 4
+                           : style.dash == EnvelopeStyle::Dash::Dashed ? 4
+                                                                       : 0;
     for (int column = 0; column < columns; ++column) {
+        if (envDashOn > 0) {
+            const int period = envDashOn + envDashOff;
+            if ((column % period) >= envDashOn) {
+                hasPrevious = false;
+                continue;
+            }
+        }
         const double startFraction =
             xStart + xSpan * double(column) / double(columns);
         const double endFraction =

--- a/src/app/TraceSceneBuilder.h
+++ b/src/app/TraceSceneBuilder.h
@@ -84,8 +84,10 @@ public:
                       const QColor& color, bool fill, qreal width);
 
     struct EnvelopeStyle {
+        enum class Dash { Solid, Dashed, Dotted };
         qreal width = 1.0;
         bool fill = false;
+        Dash dash = Dash::Solid;
         QColor color;
         QColor fillColor;
     };

--- a/src/app/TraceToolbar.qml
+++ b/src/app/TraceToolbar.qml
@@ -90,6 +90,37 @@ Item {
             onClicked: toolbar.trace.fitChannels = checked
         }
         CompactToolButton {
+            id: eventModeButton
+
+            Layout.fillHeight: true
+            Layout.maximumWidth: 56
+            Layout.minimumWidth: 56
+            Layout.preferredWidth: 56
+            checkable: true
+            checked: Store.eventMode
+            objectName: "eventModeButton"
+            text: "Event"
+            tip: Store.eventMode ? "Show the full library" : "Filter the library to this track and day"
+
+            onClicked: Store.eventMode = eventModeButton.checked
+        }
+        Label {
+            color: Style.accentColor
+            font.family: Style.monoFontFamily
+            font.pixelSize: Style.smallFontSize
+            text: Store.eventSession
+            visible: Store.eventMode && Store.eventSession !== ""
+        }
+        CompactTextField {
+            Layout.maximumWidth: 64
+            Layout.preferredWidth: 64
+            placeholderText: "c1"
+            text: Store.eventSession
+            visible: Store.eventMode
+
+            onEditingFinished: Store.eventSession = text.trim()
+        }
+        CompactToolButton {
             id: confidenceButton
 
             Layout.fillHeight: true

--- a/src/app/UsbCopyOverlay.qml
+++ b/src/app/UsbCopyOverlay.qml
@@ -1,0 +1,90 @@
+pragma ComponentBehavior: Bound
+import Omatrack
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+Rectangle {
+    id: overlay
+
+    color: Style.traceBackgroundColor
+    visible: Store.usbCopyVisible
+    z: 20
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 16
+        spacing: 10
+
+        Label {
+            font.bold: true
+            font.pixelSize: 15
+            text: Store.usbLabel === "" ? "Copy from USB" : "Copy from " + Store.usbLabel
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.mutedTextColor
+            text: "Source recordings stay on the stick. Copy adds them to the library destination using the format in Preferences."
+            wrapMode: Text.Wrap
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.accentColor
+            font.family: Style.monoFontFamily
+            font.pixelSize: Style.smallFontSize
+            text: Store.eventSession === "" ? "session unset" : "session " + Store.eventSession
+            visible: Store.eventMode
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.mutedTextColor
+            elide: Text.ElideMiddle
+            font.family: Style.monoFontFamily
+            font.pixelSize: Style.smallFontSize
+            text: Store.usbDest === "" ? Store.defaultTelemetryDirectory() : Store.usbDest
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.mutedTextColor
+            elide: Text.ElideRight
+            font.family: Style.monoFontFamily
+            font.pixelSize: Style.smallFontSize
+            text: Store.usbFormat
+        }
+        Label {
+            Layout.fillWidth: true
+            color: Style.orangeColor
+            font.family: Style.monoFontFamily
+            font.pixelSize: Style.smallFontSize
+            text: Store.usbCopyStatus
+            visible: Store.usbCopyStatus !== ""
+        }
+        ProgressBar {
+            Layout.fillWidth: true
+            from: 0
+            to: 1
+            value: Store.usbCopyProgress
+            visible: Store.usbCopyStatus !== ""
+        }
+        Item {
+            Layout.fillHeight: true
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+
+            CompactButton {
+                enabled: Store.usbCopyStatus.indexOf("Copying") !== 0
+                text: "Copy into library"
+
+                onClicked: Store.copyUsbFiles()
+            }
+            CompactButton {
+                text: "Cancel"
+
+                onClicked: Store.hideUsbCopy()
+            }
+        }
+    }
+}

--- a/src/app/VideoTelemetryHud.cpp
+++ b/src/app/VideoTelemetryHud.cpp
@@ -84,6 +84,8 @@ void VideoTelemetryHud::setStore(TelemetryStore* store) {
             snapshotDirty_ = true;
             update();
         });
+        connect(store_, &TelemetryStore::overlayStyleChanged, this,
+                [this]() { update(); });
     }
     snapshotDirty_ = true;
     update();
@@ -250,11 +252,48 @@ QSGNode* VideoTelemetryHud::updatePaintNode(QSGNode* oldNode,
                                       style, 0.0, 1.0);
         };
 
+        const bool whiteRef = store_ && store_->overlayRefWhite();
+        const QString refStyle =
+            store_ ? store_->overlayRefStyle() : QStringLiteral("dashed");
+        const QColor refColor =
+            whiteRef ? QColor(Qt::white)
+                     : QColor(store_ && !store_->overlayRefColor().isEmpty()
+                                  ? store_->overlayRefColor()
+                                  : QStringLiteral("#e09d7f"));
+        const qreal refWidth = whiteRef ? 2.4 * s : 1.5 * s;
+        auto refDash = TraceSceneBuilder::EnvelopeStyle::Dash::Dashed;
+        if (refStyle == QLatin1String("dotted"))
+            refDash = TraceSceneBuilder::EnvelopeStyle::Dash::Dotted;
+        else if (refStyle == QLatin1String("solid"))
+            refDash = TraceSceneBuilder::EnvelopeStyle::Dash::Solid;
+        const auto drawStyled =
+            [&](const std::vector<double>& values, double maximum,
+                bool reference, qreal width, const QColor& color,
+                TraceSceneBuilder::EnvelopeStyle::Dash dash) {
+                if (values.size() < 2 || !primary || primary->size() < 2 ||
+                    maximum <= 0.0)
+                    return;
+                auto sourceFraction = [&](double viewportFrac) -> double {
+                    const double pf = std::clamp(viewportFrac, 0.0, 1.0);
+                    return reference
+                               ? snapshot_.compareFractionForPrimaryFraction(pf)
+                               : pf;
+                };
+                TraceSceneBuilder::EnvelopeStyle style;
+                style.width = width;
+                style.color = color;
+                style.dash = dash;
+                builder_.envelopePolyline(values, sourceFraction, windowStart,
+                                          kWindowFrac, graphRect, 0.0, maximum,
+                                          style, 0.0, 1.0);
+            };
         if (compare) {
-            drawTrace(compare->throttle, 1.0, true, 1.5 * s,
-                      withAlpha(throttleColor_, 150));
-            drawTrace(compare->brake, brakeMax, true, 1.5 * s,
-                      withAlpha(brakeColor_, 150));
+            drawStyled(compare->throttle, 1.0, true, refWidth,
+                       withAlpha(whiteRef ? QColor(Qt::white) : refColor, 200),
+                       refDash);
+            drawStyled(compare->brake, brakeMax, true, refWidth,
+                       withAlpha(whiteRef ? QColor(Qt::white) : refColor, 200),
+                       refDash);
         }
         drawTrace(primaryThrottle, throttleScale, false, 2.5 * s,
                   throttleColor_);

--- a/src/core/TelemetryEngine.cpp
+++ b/src/core/TelemetryEngine.cpp
@@ -207,10 +207,19 @@ std::vector<double> pdsDistanceSplits(const std::vector<double>& values,
                                       int freq) {
     std::vector<double> splits;
     if (freq <= 0 || values.size() < 2) return splits;
+    double peak = 0.0;
+    for (double value : values) {
+        if (std::isfinite(value) && value > peak) peak = value;
+    }
+    if (!(peak > 0.0)) return splits;
+    // Half the observed peak, not a hardcoded 300 m: a 4 km oval reported
+    // in kilometres (wrap of ~4) never clears 300, so detectLaps would
+    // invent a single fragment instead of laps.
+    const double dropThreshold = peak * 0.5;
     int lastSplitIndex = -std::max(1, freq);
     int clusterGap = std::max(1, freq / 2);
     for (size_t i = 1; i < values.size(); ++i) {
-        if (values[i - 1] - values[i] > 300 &&
+        if (values[i - 1] - values[i] > dropThreshold &&
             int(i) - lastSplitIndex >= clusterGap) {
             splits.push_back(double(i) / double(freq));
             lastSplitIndex = int(i);
@@ -300,6 +309,23 @@ void markShortCrossingsIncomplete(std::vector<Lap>& laps) {
     }
 }
 
+void restoreRepresentativeCrossings(std::vector<Lap>& laps) {
+    std::vector<double> seconds;
+    for (const Lap& lap : laps) {
+        if (!std::isfinite(lap.timeMs) || !(lap.timeMs > 0.0)) continue;
+        seconds.push_back(lap.timeMs / 1000.0);
+    }
+    if (seconds.empty()) return;
+    std::sort(seconds.begin(), seconds.end());
+    const double median = seconds[seconds.size() / 2];
+    const double minSeconds =
+        seconds.size() >= 3 ? median * 0.5 : std::max(median * 0.5, 30.0);
+    for (Lap& lap : laps) {
+        if (lap.complete) continue;
+        if (lap.timeMs / 1000.0 >= minSeconds) lap.complete = true;
+    }
+}
+
 std::vector<Lap> pdsApplyPreviousLapTimes(
     const std::vector<Lap>& laps,
     const std::vector<double>& previousLapTimeValues, int freq,
@@ -364,7 +390,6 @@ std::vector<Lap> pdsApplyLapDistanceCoverage(
     if (!(sessionRange > 0.0)) return laps;
 
     std::vector<double> coverage(laps.size(), -1.0);
-    double maxCoverage = 0.0;
     for (size_t i = 0; i < laps.size(); ++i) {
         if (!laps[i].complete) continue;
         const size_t begin =
@@ -374,17 +399,25 @@ std::vector<Lap> pdsApplyLapDistanceCoverage(
         if (begin >= lapDistanceValues.size() || end > lapDistanceValues.size())
             continue;
         coverage[i] = range(begin, end) / sessionRange;
-        maxCoverage = std::max(maxCoverage, coverage[i]);
     }
 
+    std::vector<double> typical;
+    typical.reserve(coverage.size());
+    for (double value : coverage)
+        if (value >= 0.0) typical.push_back(value);
+    if (typical.size() < 2) return laps;
+    std::sort(typical.begin(), typical.end());
+    const double medianCoverage = typical[typical.size() / 2];
     // A session-cumulative distance channel cannot validate individual laps:
-    // no one crossing pair spans most of its total range.
-    if (maxCoverage < 0.75) return laps;
+    // no typical crossing pair spans most of its total range. Compare against
+    // the median, not the max: one GPS-spike lap on an oval must not mark
+    // every racing crossing as Frag.
+    if (medianCoverage < 0.75) return laps;
 
     std::vector<Lap> out = laps;
     for (size_t i = 0; i < out.size(); ++i) {
         if (out[i].complete && coverage[i] >= 0.0 &&
-            coverage[i] < maxCoverage * 0.5)
+            coverage[i] < medianCoverage * 0.5)
             out[i].complete = false;
     }
     return out;
@@ -1388,6 +1421,7 @@ std::vector<Lap> TelemetrySource::detectLaps() const {
     if (!sourceLaps_.empty()) {
         std::vector<Lap> laps = sourceLaps_;
         markShortCrossingsIncomplete(laps);
+        restoreRepresentativeCrossings(laps);
         if (!lapDistance.empty())
             laps = pdsApplyLapDistanceCoverage(laps, lapDistance,
                                                std::max(1, distanceFreq));

--- a/src/core/TelemetryEngineInternal.h
+++ b/src/core/TelemetryEngineInternal.h
@@ -45,7 +45,9 @@ std::vector<double> selectLapSplits(const std::vector<double>& beaconSplits,
                                     const std::vector<double>& lapTimeSplits,
                                     const std::vector<double>& distanceSplits);
 
-/// Splits from a cumulative lap-distance channel (detects resets > 300 m).
+/// Splits from a wrapping lap-distance channel. A reset is a drop of more
+/// than half the observed peak, so metre, kilometre, percent, and 0-1
+/// fraction channels all work (a 300 m floor misses a 4 km oval in km).
 std::vector<double> pdsDistanceSplits(const std::vector<double>& values,
                                       int freq);
 
@@ -61,6 +63,12 @@ std::vector<Lap> buildLapsFromSplits(const std::vector<double>& splitTimes,
 /// Used for both heuristic splits and vendor-supplied lap lists so an out-lap
 /// cannot win fastest-lap selection.
 void markShortCrossingsIncomplete(std::vector<Lap>& laps);
+
+/// Promote vendor-incomplete laps whose time matches the session median.
+/// AiM/Pi often flag oval crossings incomplete when the logger's track map
+/// is the road course; upstream still found the laps, so classification
+/// (not a second detector) decides complete vs Out/In/Frag.
+void restoreRepresentativeCrossings(std::vector<Lap>& laps);
 
 /// Override lap times from a "previous lap time" channel when it agrees with
 /// the crossing-derived estimate; heuristic contradictory crossings can be

--- a/tests/AppTypesTest.cpp
+++ b/tests/AppTypesTest.cpp
@@ -179,6 +179,51 @@ private slots:
     }
 };
 
+class ActiveSessionRolesTest : public QObject {
+    Q_OBJECT
+private slots:
+    void emptyAgrees() { QVERIFY(ActiveSessionRoles{}.agree()); }
+    void setPrimarySelectLapSidebarAgree() {
+        ActiveSessionRoles roles;
+        roles.sessionKey = QStringLiteral("/indy.mp4");
+        roles.videoIdentity = QStringLiteral("/indy.mp4");
+        roles.filmstripKey = QStringLiteral("/indy.mp4");
+        roles.sidebarKey = QStringLiteral("/indy.mp4");
+        QVERIFY(roles.agree());
+    }
+    void nonVideoEmptyIdentityAgrees() {
+        ActiveSessionRoles roles;
+        roles.sessionKey = QStringLiteral("/session.ld");
+        roles.filmstripKey = QStringLiteral("/session.ld");
+        roles.sidebarKey = QStringLiteral("/session.ld");
+        QVERIFY(roles.agree());
+    }
+    void staleVideoFails() {
+        ActiveSessionRoles roles;
+        roles.sessionKey = QStringLiteral("/a.mp4");
+        roles.videoIdentity = QStringLiteral("/b.mp4");
+        roles.filmstripKey = QStringLiteral("/a.mp4");
+        roles.sidebarKey = QStringLiteral("/a.mp4");
+        QVERIFY(!roles.agree());
+    }
+    void filmstripMismatchFails() {
+        ActiveSessionRoles roles;
+        roles.sessionKey = QStringLiteral("/a.mp4");
+        roles.videoIdentity = QStringLiteral("/a.mp4");
+        roles.filmstripKey = QStringLiteral("/b.mp4");
+        roles.sidebarKey = QStringLiteral("/a.mp4");
+        QVERIFY(!roles.agree());
+    }
+    void sidebarMismatchFails() {
+        ActiveSessionRoles roles;
+        roles.sessionKey = QStringLiteral("/a.mp4");
+        roles.videoIdentity = QStringLiteral("/a.mp4");
+        roles.filmstripKey = QStringLiteral("/a.mp4");
+        roles.sidebarKey = QStringLiteral("/b.mp4");
+        QVERIFY(!roles.agree());
+    }
+};
+
 // Run all test classes in one executable.
 int main(int argc, char* argv[]) {
     int status = 0;
@@ -200,6 +245,10 @@ int main(int argc, char* argv[]) {
     }
     {
         CornerMarkerTest t;
+        status |= QTest::qExec(&t, argc, argv);
+    }
+    {
+        ActiveSessionRolesTest t;
         status |= QTest::qExec(&t, argc, argv);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -121,6 +121,67 @@ target_link_libraries(usb-media-test PRIVATE
 add_test(NAME usb-media-test COMMAND usb-media-test)
 set_tests_properties(usb-media-test PROPERTIES LABELS unit)
 
+qt_add_executable(library-model-test LibraryModelTest.cpp
+  ${CMAKE_SOURCE_DIR}/src/app/LibraryModel.cpp)
+target_include_directories(library-model-test PRIVATE
+  ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(library-model-test PRIVATE
+  Qt6::Test
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Qml
+  omatrack_warnings)
+add_test(NAME library-model-test COMMAND library-model-test)
+set_tests_properties(library-model-test PROPERTIES LABELS unit)
+
+qt_add_executable(lua-rename-test LuaRenameTest.cpp
+  ${CMAKE_SOURCE_DIR}/src/app/LuaRename.cpp
+  ${CMAKE_SOURCE_DIR}/src/app/PathJail.cpp)
+target_include_directories(lua-rename-test PRIVATE
+  ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(lua-rename-test PRIVATE
+  Qt6::Test
+  Qt6::Core
+  lua_sandbox
+  sol2_headers
+  omatrack_warnings)
+add_test(NAME lua-rename-test COMMAND lua-rename-test)
+set_tests_properties(lua-rename-test PROPERTIES LABELS unit)
+
+qt_add_executable(index-cache-test IndexCacheTest.cpp
+  ${CMAKE_SOURCE_DIR}/src/app/IndexCache.cpp)
+target_include_directories(index-cache-test PRIVATE
+  ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(index-cache-test PRIVATE
+  Qt6::Test
+  Qt6::Core
+  omatrack_core
+  omatrack_warnings)
+add_test(NAME index-cache-test COMMAND index-cache-test)
+set_tests_properties(index-cache-test PROPERTIES LABELS unit)
+
+qt_add_executable(overlay-style-test OverlayStyleTest.cpp)
+target_include_directories(overlay-style-test PRIVATE
+  ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(overlay-style-test PRIVATE
+  Qt6::Test
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Quick
+  omatrack_warnings)
+add_test(NAME overlay-style-test COMMAND overlay-style-test)
+set_tests_properties(overlay-style-test PROPERTIES LABELS unit)
+
+qt_add_executable(swap-roles-test SwapRolesTest.cpp)
+target_include_directories(swap-roles-test PRIVATE
+  ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(swap-roles-test PRIVATE
+  Qt6::Test
+  Qt6::Core
+  omatrack_warnings)
+add_test(NAME swap-roles-test COMMAND swap-roles-test)
+set_tests_properties(swap-roles-test PROPERTIES LABELS unit)
+
 # ── Omarchy theme bridge test ───────────────────────────────────────
 qt_add_executable(omarchy-theme-test OmarchyThemeTest.cpp
   ${CMAKE_SOURCE_DIR}/src/app/OmarchyTheme.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,7 +122,8 @@ add_test(NAME usb-media-test COMMAND usb-media-test)
 set_tests_properties(usb-media-test PROPERTIES LABELS unit)
 
 qt_add_executable(library-model-test LibraryModelTest.cpp
-  ${CMAKE_SOURCE_DIR}/src/app/LibraryModel.cpp)
+  ${CMAKE_SOURCE_DIR}/src/app/LibraryModel.cpp
+  ${CMAKE_SOURCE_DIR}/src/app/StoreModels.cpp)
 target_include_directories(library-model-test PRIVATE
   ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(library-model-test PRIVATE

--- a/tests/CoreTest.cpp
+++ b/tests/CoreTest.cpp
@@ -363,6 +363,15 @@ private slots:
         for (int i = 0; i < 500; ++i) v.push_back(double(i) * 10);
         QVERIFY(pdsDistanceSplits(v, 10).empty());
     }
+    void kilometreScaleWrapIsAReset() {
+        // IMS oval ~4 km reported in kilometres never clears a 300 m floor.
+        std::vector<double> v;
+        for (int i = 0; i < 400; ++i) v.push_back(double(i) * 0.01);
+        for (int i = 0; i < 400; ++i) v.push_back(double(i) * 0.01);
+        const std::vector<double> splits = pdsDistanceSplits(v, 10);
+        QVERIFY(splits.size() >= 1);
+        QCOMPARE(splits[0], 40.0);
+    }
 };
 
 // ────────────────────────────────────────────────────────────────────
@@ -528,6 +537,35 @@ private slots:
             pdsApplyLapDistanceCoverage(laps, position, 1);
         QVERIFY(checked[0].complete);
         QVERIFY(checked[1].complete);
+    }
+    void outlierCoverageDoesNotRejectTypicalLaps() {
+        // Three similar oval laps plus one GPS-spike pair that spans the
+        // whole session range. Median coverage is low; racing laps stay.
+        const std::vector<Lap> laps{Lap{0, 0.0, 40.0, 40000.0, true},
+                                    Lap{1, 40.0, 80.0, 40000.0, true},
+                                    Lap{2, 80.0, 120.0, 40000.0, true},
+                                    Lap{3, 120.0, 160.0, 40000.0, true}};
+        std::vector<double> position(161, 0.0);
+        for (int i = 0; i <= 120; ++i) position[size_t(i)] = double(i % 41);
+        for (int i = 121; i <= 160; ++i) position[size_t(i)] = double(i);
+
+        const std::vector<Lap> checked =
+            pdsApplyLapDistanceCoverage(laps, position, 1);
+        QVERIFY(checked[0].complete);
+        QVERIFY(checked[1].complete);
+        QVERIFY(checked[2].complete);
+        QVERIFY(checked[3].complete);
+    }
+    void restorePromotesVendorIncompleteRacingLaps() {
+        std::vector<Lap> laps{Lap{1, 0.0, 80.0, 80000.0, false},
+                              Lap{2, 80.0, 160.0, 80000.0, false},
+                              Lap{3, 160.0, 241.0, 81000.0, false},
+                              Lap{4, 241.0, 260.0, 19000.0, false}};
+        restoreRepresentativeCrossings(laps);
+        QVERIFY(laps[0].complete);
+        QVERIFY(laps[1].complete);
+        QVERIFY(laps[2].complete);
+        QVERIFY(!laps[3].complete);
     }
 };
 
@@ -1186,6 +1224,21 @@ private slots:
         QCOMPARE(laps[0].timeMs, 19750.0);
         QVERIFY(laps[0].complete);
         QVERIFY(!laps[0].sourceNumber.has_value());
+    }
+
+    void detectLapsRestoresVendorIncompleteRacingLaps() {
+        TelemetrySource src;
+        src.sourceLaps() = {Lap{1, 0.0, 80.0, 80000.0, false},
+                            Lap{2, 80.0, 160.0, 80000.0, false},
+                            Lap{3, 160.0, 241.0, 81000.0, false},
+                            Lap{4, 241.0, 260.0, 19000.0, false}};
+
+        const std::vector<Lap> laps = src.detectLaps();
+        QCOMPARE(laps.size(), size_t(4));
+        QVERIFY(laps[0].complete);
+        QVERIFY(laps[1].complete);
+        QVERIFY(laps[2].complete);
+        QVERIFY(!laps[3].complete);
     }
 
     void unifyLapNormalizesSyntheticChannels() {

--- a/tests/IndexCacheTest.cpp
+++ b/tests/IndexCacheTest.cpp
@@ -1,0 +1,43 @@
+#include "app/IndexCache.h"
+#include "core/TelemetryEngine.h"
+
+#include <QFile>
+#include <QTemporaryDir>
+#include <QTest>
+
+class IndexCacheTest : public QObject {
+    Q_OBJECT
+private slots:
+    void identityIncludesGeneration() {
+        QTemporaryDir directory;
+        QVERIFY(directory.isValid());
+        const QString path = directory.filePath(QStringLiteral("session.ld"));
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        QCOMPARE(file.write("not-a-real-session"), 18);
+        file.close();
+
+        const omatrack::FileIdentity identity = omatrack::fileIdentity(path);
+        QVERIFY(identity.valid);
+        QCOMPARE(identity.generation,
+                 QString::fromStdString(omatrack::converterGeneration()));
+        const QString cachePath = omatrack::indexCachePath(identity);
+        QVERIFY(cachePath.contains(identity.generation));
+        QVERIFY(!cachePath.contains(QStringLiteral(".telemetry")));
+    }
+
+    void doesNotCacheEmptyMetadata() {
+        QTemporaryDir directory;
+        QVERIFY(directory.isValid());
+        const QString path = directory.filePath(QStringLiteral("session.ld"));
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::WriteOnly));
+        file.write("x");
+        file.close();
+        QVERIFY(!omatrack::storeIndexCache(path, {}));
+        QVERIFY(omatrack::loadIndexCache(path).isEmpty());
+    }
+};
+
+QTEST_GUILESS_MAIN(IndexCacheTest)
+#include "IndexCacheTest.moc"

--- a/tests/LibraryModelTest.cpp
+++ b/tests/LibraryModelTest.cpp
@@ -1,4 +1,5 @@
 #include "app/LibraryModel.h"
+#include "app/StoreModels.h"
 
 #include <QAbstractItemModel>
 #include <QSignalSpy>
@@ -38,6 +39,42 @@ private slots:
         QCOMPARE(reset.size(), 0);
         QVERIFY(inserted.size() >= 1);
         QCOMPARE(model.rowCount(), 3);
+    }
+
+    void setPrimarySelectLapSidebarAgree() {
+        LibraryModel library;
+        FilmstripSessionListModel filmstrip;
+        const QString key = QStringLiteral("/tmp/indy.mp4");
+
+        library.updateSelection(key, QString());
+        FilmstripSessionRow row;
+        row.sessionKey = key;
+        row.reference = false;
+        filmstrip.refresh({row});
+
+        ActiveSessionRoles roles;
+        roles.sessionKey = key;
+        roles.videoIdentity = key;
+        roles.filmstripKey = filmstrip.primarySessionKey();
+        roles.sidebarKey = library.primarySessionKey();
+        QVERIFY(roles.agree());
+
+        const QString other = QStringLiteral("/tmp/other.mp4");
+        library.updateSelection(other, QString());
+        row.sessionKey = other;
+        filmstrip.refresh({row});
+        roles.sessionKey = other;
+        roles.videoIdentity = other;
+        roles.filmstripKey = filmstrip.primarySessionKey();
+        roles.sidebarKey = library.primarySessionKey();
+        QVERIFY(roles.agree());
+
+        library.updateSelection(QString(), QString());
+        filmstrip.refresh({});
+        roles = ActiveSessionRoles{};
+        roles.filmstripKey = filmstrip.primarySessionKey();
+        roles.sidebarKey = library.primarySessionKey();
+        QVERIFY(roles.agree());
     }
 
     void filterDoesNotReset() {

--- a/tests/LibraryModelTest.cpp
+++ b/tests/LibraryModelTest.cpp
@@ -1,0 +1,67 @@
+#include "app/LibraryModel.h"
+
+#include <QAbstractItemModel>
+#include <QSignalSpy>
+#include <QTest>
+
+class LibraryModelTest : public QObject {
+    Q_OBJECT
+private slots:
+    void refreshDoesNotReset() {
+        LibraryModel model;
+        QVariantList sources;
+        sources.append(QVariantMap{
+            {QStringLiteral("role"), QStringLiteral("source")},
+            {QStringLiteral("name"), QStringLiteral("Local")},
+            {QStringLiteral("path"), QStringLiteral("/tmp/a")},
+            {QStringLiteral("children"),
+             QVariantList{QVariantMap{
+                 {QStringLiteral("role"), QStringLiteral("file")},
+                 {QStringLiteral("name"), QStringLiteral("a.ld")},
+                 {QStringLiteral("path"), QStringLiteral("/tmp/a/a.ld")},
+                 {QStringLiteral("key"), QStringLiteral("/tmp/a/a.ld")},
+                 {QStringLiteral("hasSession"), true},
+             }}},
+        });
+        model.setTree(sources);
+        QCOMPARE(model.rowCount(), 2);
+
+        QSignalSpy reset(&model, &QAbstractItemModel::modelReset);
+        QSignalSpy inserted(&model, &QAbstractItemModel::rowsInserted);
+        sources.append(QVariantMap{
+            {QStringLiteral("role"), QStringLiteral("source")},
+            {QStringLiteral("name"), QStringLiteral("USB — Stick")},
+            {QStringLiteral("path"), QStringLiteral("/media/stick")},
+            {QStringLiteral("children"), QVariantList{}},
+        });
+        model.setTree(sources);
+        QCOMPARE(reset.size(), 0);
+        QVERIFY(inserted.size() >= 1);
+        QCOMPARE(model.rowCount(), 3);
+    }
+
+    void filterDoesNotReset() {
+        LibraryModel model;
+        LibraryFilterModel filter;
+        filter.setSourceModel(&model);
+        model.setTree(QVariantList{QVariantMap{
+            {QStringLiteral("role"), QStringLiteral("file")},
+            {QStringLiteral("name"), QStringLiteral("a.ld")},
+            {QStringLiteral("path"), QStringLiteral("/tmp/a.ld")},
+            {QStringLiteral("key"), QStringLiteral("/tmp/a.ld")},
+            {QStringLiteral("track"), QStringLiteral("Sebring")},
+            {QStringLiteral("sessionDayKey"), QStringLiteral("2026-08-30")},
+        }});
+        QSignalSpy reset(&filter, &QAbstractItemModel::modelReset);
+        filter.setSelectedTrack(QStringLiteral("Sebring"));
+        filter.setSelectedDay(QStringLiteral("2026-08-30"));
+        QCOMPARE(reset.size(), 0);
+        QCOMPARE(filter.rowCount(), 1);
+        filter.setSelectedTrack(QStringLiteral("Road America"));
+        QCOMPARE(filter.rowCount(), 0);
+        QCOMPARE(reset.size(), 0);
+    }
+};
+
+QTEST_GUILESS_MAIN(LibraryModelTest)
+#include "LibraryModelTest.moc"

--- a/tests/LuaRenameTest.cpp
+++ b/tests/LuaRenameTest.cpp
@@ -1,0 +1,70 @@
+#include "app/LuaRename.h"
+#include "app/PathJail.h"
+
+#include <QDir>
+#include <QTest>
+
+class LuaRenameTest : public QObject {
+    Q_OBJECT
+private slots:
+    void emptyScriptOk() {
+        const auto result = omatrack::runLuaRename({}, {});
+        QVERIFY(result.ok);
+        QVERIFY(result.relativePath.isEmpty());
+    }
+
+    void returnsRelativePath() {
+        const auto result = omatrack::runLuaRename(
+            QStringLiteral("function rename(ctx) return ctx.track .. "
+                           "\"/\" .. ctx.original end"),
+            QVariantMap{{QStringLiteral("track"), QStringLiteral("sebring")},
+                        {QStringLiteral("original"), QStringLiteral("a.ld")}});
+        QVERIFY2(result.ok, qPrintable(result.error));
+        QCOMPARE(result.relativePath, QStringLiteral("sebring/a.ld"));
+    }
+
+    void loadIsBlocked() {
+        const auto result = omatrack::runLuaRename(
+            QStringLiteral("function rename(ctx) return load(\"return 1\")() "
+                           ".. \"x\" end"),
+            {});
+        QVERIFY(!result.ok);
+    }
+
+    void stringRepIsCapped() {
+        const auto result = omatrack::runLuaRename(
+            QStringLiteral("function rename(ctx) return string.rep(\"a\", "
+                           "10000000) end"),
+            {}, 50, 64 * 1024);
+        QVERIFY(!result.ok);
+        QVERIFY(result.error.contains(QStringLiteral("memory")) ||
+                result.error.contains(QStringLiteral("timed")));
+    }
+
+    void jailRejectsDotDot() {
+        const auto jailed = omatrack::jailRelativePath(
+            QStringLiteral("/tmp/dest"), QStringLiteral("../etc/passwd"));
+        QVERIFY(!jailed.ok);
+    }
+
+    void jailRejectsAbsolute() {
+        QVERIFY(omatrack::isForbiddenRelative(QStringLiteral("/etc/passwd")));
+        QVERIFY(omatrack::isForbiddenRelative(QStringLiteral("C:/Windows")));
+        QVERIFY(
+            omatrack::isForbiddenRelative(QStringLiteral("\\\\server\\share")));
+    }
+
+    void jailAcceptsNested() {
+        const QString dest =
+            QDir::temp().filePath(QStringLiteral("omatrack-jail"));
+        QVERIFY(QDir().mkpath(dest));
+        const auto jailed = omatrack::jailRelativePath(
+            dest, QStringLiteral("sebring/2026-08-30/c1/a.ld"));
+        QVERIFY2(jailed.ok, qPrintable(jailed.error));
+        QVERIFY(jailed.absolutePath.startsWith(QDir(dest).canonicalPath()) ||
+                jailed.absolutePath.startsWith(QDir::cleanPath(dest)));
+    }
+};
+
+QTEST_GUILESS_MAIN(LuaRenameTest)
+#include "LuaRenameTest.moc"

--- a/tests/OverlayStyleTest.cpp
+++ b/tests/OverlayStyleTest.cpp
@@ -1,0 +1,29 @@
+#include "app/TraceSceneBuilder.h"
+
+#include <QtGlobal>
+#include <QTest>
+
+class OverlayStyleTest : public QObject {
+    Q_OBJECT
+private slots:
+    void defaultIsSolidPrimaryWidth() {
+        TraceSceneBuilder::EnvelopeStyle primary;
+        primary.width = 2.5;
+        QCOMPARE(primary.dash, TraceSceneBuilder::EnvelopeStyle::Dash::Solid);
+
+        TraceSceneBuilder::EnvelopeStyle reference;
+        reference.width = 2.4;
+        reference.dash = TraceSceneBuilder::EnvelopeStyle::Dash::Dashed;
+        QVERIFY(reference.dash != primary.dash);
+        QVERIFY(qAbs(reference.width - primary.width) < 0.2);
+    }
+
+    void whitePresetKeepsSimilarThickness() {
+        const qreal primary = 2.5;
+        const qreal whiteRef = 2.4;
+        QVERIFY(qAbs(whiteRef - primary) < 0.2);
+    }
+};
+
+QTEST_GUILESS_MAIN(OverlayStyleTest)
+#include "OverlayStyleTest.moc"

--- a/tests/SwapRolesTest.cpp
+++ b/tests/SwapRolesTest.cpp
@@ -1,0 +1,15 @@
+#include "app/SwapRoles.h"
+
+#include <QTest>
+
+class SwapRolesTest : public QObject {
+    Q_OBJECT
+private slots:
+    void noOpWithoutReference() {
+        QVERIFY(!omatrack::swapRolesPossible(false));
+        QVERIFY(omatrack::swapRolesPossible(true));
+    }
+};
+
+QTEST_GUILESS_MAIN(SwapRolesTest)
+#include "SwapRolesTest.moc"

--- a/tests/UsbMediaTest.cpp
+++ b/tests/UsbMediaTest.cpp
@@ -74,6 +74,13 @@ private slots:
         QVERIFY(!omatrack::isUsbBlockDevice(
             QByteArrayLiteral("/dev/does-not-exist"), sys));
     }
+
+    void listingDoesNotCopyOrPersist() {
+        const auto first = omatrack::mountedUsbVolumes();
+        const auto second = omatrack::mountedUsbVolumes();
+        QCOMPARE(first, second);
+        for (const auto& volume : first) QVERIFY(!volume.rootPath.isEmpty());
+    }
 };
 
 QTEST_GUILESS_MAIN(UsbMediaTest)


### PR DESCRIPTION
## Summary

- Header update control shows AppUpdater download percent and bytes next to the icon (worker thread, `IoCancel`, no nested `QEventLoop`).
- Sidebar, channels, laps, and other list models refresh with insert/remove/`dataChanged` instead of `beginResetModel`. `LibraryFilterModel` uses `invalidateFilter` / `beginFilterChange`. Scroll position is saved before the change and restored after. `reuseItems: true`, `highlightFollowsCurrentItem: false`.
- Event mode toolbar toggle filters the library to a known track and today/event date. Session name (`c1`, `c2`, …) is a first-class field, shown in the toolbar, passed into USB copy and Lua rename `ctx`, and stored in `omatrack.yml`.
- `mountedUsbVolumes()` is wired. USB mounts are a transient `USB — …` sidebar section (never persisted into `locations`). Copy is a separate overlay in the video slot; source files stay immutable. Dest + `{track}/{date}/{session}/{original}` live in `omatrack.yml`.
- Optional Lua 5.4 + sol2 rename sandbox in `src/app`: no `io`/`os`, `load`/`loadfile`/`dofile`/`setmetatable` stripped, COUNT hook + wall-clock + memory cap (blocks `string.rep`). `rename(ctx)` returns a jailed relative path.
- Location roots and USB mounts debounce into the existing scan `AsyncJob`.
- Sidebar `openIndex` cache under `$XDG_CACHE_HOME/omatrack/index/{generation}/`, keyed by POSIX `(dev, ino, size, mtime)` plus `omatrack::converterGeneration()`. Failures are not stored. Nothing is written beside the source.
- Fullscreen overlay reference traces take color, dash/dot, and a white similar-thickness preset from preferences (C++ scene-graph uniforms, no QML Canvas).
- `X` swaps primary ↔ reference analysis roles (no-op without a reference). Same action on the filmstrip label. Text fields keep `X`.

## Test plan

- [x] `library-model-test` — refresh/filter does not `modelReset`
- [x] `usb-media-test` — detect listing does not copy or persist
- [x] `lua-rename-test` — path jail, `load` blocked, `string.rep` capped
- [x] `index-cache-test` — cache key includes `converterGeneration()`; empty metadata not stored
- [x] `overlay-style-test` — white/dash prefs keep similar thickness
- [x] `swap-roles-test` — swap is a no-op without a reference
- [ ] Full `omatrack` GUI binary: this box has Qt 6.8.2; `QSGGeometry::setIndexCount`/`setVertexCount` need Qt 6.9+ (CI uses 6.11.1). Merge CI should compile the app.
- [ ] After merge: tag `v1.6.1` from main so `release.yml` publishes Linux/Windows/macOS assets.

## Release

v1.6.0 is an annotated tag on the merged main commit `d95a4af` (CI `release.yml` runs on `v*.*.*` tags and checks they match `project(omatrack VERSION …)`). Do not tag this branch and do not attach a handmade binary.

**Merge this PR, then tag `v1.6.1` on main.** That is what cuts the GitHub release.