### PR TITLE
1.7.1: video is the clock, deadline queue for telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ Interactive rendering targets 60–120 fps. A frame is 16.67 ms at 60 Hz and 8.3
 - Cache normalized laps, raw-channel resamples, delta arrays, geometry, and overview rasters; invalidate them only when their inputs change.
 - Bound draw work to the viewport and pixel budget. Do not submit every source sample when fewer points can produce the same image.
 - Avoid per-frame heap allocation and avoid copies of full telemetry arrays.
+  libmpv `time-pos` must not fan out into store/HUD/header/trace work; enqueue
+  it on `DeadlineQueue` and pump independently of the player callback.
 - Benchmark hover and zoom paths before and after renderer changes. A visually correct regression that misses the frame budget is not complete.
 
 ### Native Linux and Omarchy are deliberate
@@ -357,8 +359,12 @@ Native lap distance is accepted only when its continuity and total agree with in
 - Place video in the resizable section above the traces. Playback chrome stays minimal: the top-left speaker button toggles persisted audio mute, Space toggles playback, and Left/Right skip the primary recording by 2 seconds. Store the mute preference under `video.muted` in `omatrack.yml`. Fullscreen dual-video compose is split, active-with-reference pip, reference-with-active pip, active only, or reference only (keys 1–5). In pip layouts the main recording is inset so it is not confused with a single full-frame video. `S` toggles 0.25× slow motion on the primary clock (the reference follows). The top bar shows the layout name, then driver / lap N/M / fuel for the active and reference recordings.
 - Selecting an AiM video session selects its fastest lap and pauses at the
   telemetry cursor. The primary recording is the clock: it always plays at
-  1×, each frame advances the telemetry cursor and traces, and it is never
-  rate-corrected or sought to chase telemetry during play. An explicit cursor
+  1×, publishes `time-pos` into `MpvVideoItem::position_`, and is never
+  rate-corrected or sought to chase telemetry during play. Overlay, header
+  and traces sample that position through `DeadlineQueue` (latest-wins per
+  key, priority, deadline) pumped from `QTimer` / `QQuickWindow::afterAnimating`,
+  never from `processEvents`. Seek and pause upsert the same keys with
+  deadline-now. An explicit cursor
   jump still seeks both recordings. Reaching the end of the current lap
   pauses, shows a short next-lap 3-2-1, then selects the next lap in the same
   session and resumes; the reference lap is not changed. Primary/reference
@@ -592,8 +598,8 @@ Warnings (`-Wall -Wextra`) come from the `omatrack_warnings` interface target.
 | App updates | `src/app/AppUpdate.*`, `src/app/AppUpdater.*`, `src/app/WindowsAssociations.*` | GitHub latest-release parse, SHA-256 verify, AppImage replace, Velopack `Update.exe` apply, macOS dmg stage-and-swap, Windows file associations, header/preferences state | Telemetry, Track Atlas |
 | Remote protocols | `src/app/WebDavBackend.cpp`, `src/app/S3Backend.cpp`, `src/app/SigV4.*` | Listing a server and signing a request — PROPFIND/XML, ListObjectsV2, AWS Signature Version 4 | Cache layout, eviction policy, anything that outlives one request |
 | Renderer | `src/app/TraceView.*`, `src/app/TraceLaneLayout.*`, `src/app/TraceInteraction.*`, `src/app/TraceSceneBuilder.*`, `src/app/TraceTextCache.*`, `src/app/TraceSnapshot.h` | Scene-graph geometry generation for the trace surfaces (one shared `envelopePolyline` decimator), lane layout, direct trace interaction; every surface reads store state through the read-only `TraceSnapshot` | Parsing, network access, persistent product state, `friend` access into the store |
-| Video sync | `src/app/VideoSyncController.*` | Primary/reference playback timing: reference rate, hard seeks, slow motion, next-lap countdown | Layout, media decoding, alignment math |
-| Video renderer | `src/app/MpvVideoItem.*` | libmpv lifecycle, OpenGL FBO rendering, playback state, and exact seek | Telemetry extraction, session association, or QML layout policy |
+| Video sync | `src/app/VideoSyncController.*`, `src/app/DeadlineQueue.*` | Primary/reference playback timing: reference rate, hard seeks, slow motion, next-lap countdown; GUI-thread deadline queue that samples published video position for cursor/HUD/header/channels | Layout, media decoding, alignment math, overlay work inside `MpvVideoItem::processEvents` |
+| Video renderer | `src/app/MpvVideoItem.*` | libmpv lifecycle, OpenGL FBO rendering, playback state, and exact seek | Telemetry extraction, session association, QML layout policy, or `setCursorFromVideoTime` |
 | QML UI | `src/app/*.qml` | Material windows, layout, delegates, controls, high-level orchestration | Full telemetry loops, duplicated analysis, format branches |
 | Bootstrap | `src/app/main.cpp`, `src/app/SingleInstance.*` | Qt startup, style, fonts, store ownership, initial properties, module load, single-instance path hand-off; headless command dispatch before Qt | Product analysis, autotest behaviour |
 | Session/store | `src/app/TelemetryStore.*` + collaborators `PreferencesStore.*`, `TrackAtlasManager.*`, `OverlayManager.*`, `LibraryModel.*`, `StoreModels.*`/`StoreTypes.h`, `AsyncJob.h` | Lazy session handles, ETag-keyed normalized telemetry cache for remote recordings, selection, cached selectable primary→reference alignment, comparison, viewport; preferences (debounced `omatrack.yml` writer), Track Atlas, MTX overlays, the library tree model and typed row models/gadgets handed to QML; every background pipeline is an `AsyncJob`/`SerialJobQueue` | Pixel-level paint loops, vendor byte parsing, self-update, hand-rolled `QFutureWatcher`/generation counters |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable user-facing changes are documented here.
 
+## 1.7.1 — 2026-09-02
+
+- Video publishes its position; overlay, header and traces sample it through
+  a deadline queue at display refresh and never run inside the player
+  callback, so Windows laptops stop dropping frames. USB, import and plugins
+  are unchanged.
+
 ## 1.7.0 — 2026-08-31
 
 - Preferences → Plugins: plugin folder, enable/disable, reload, and an

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(omatrack VERSION 1.7.0 LANGUAGES CXX)
+project(omatrack VERSION 1.7.1 LANGUAGES CXX)
 if(WIN32)
   # Windows release layout: the app ships as a flat zip, so executables and
   # their load-time DLLs install at the prefix root and every non-binary

--- a/src/app/AppHeader.qml
+++ b/src/app/AppHeader.qml
@@ -68,7 +68,7 @@ ToolBar {
     }
 
     Connections {
-        function onCursorFracChanged(): void {
+        function onCursorReadoutChanged(): void {
             readout.refresh();
         }
         function onRecentFilesChanged(): void {

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -130,6 +130,7 @@ qt_add_qml_module(omatrack
     TraceView.h TraceView.cpp
     VideoTelemetryHud.h VideoTelemetryHud.cpp
     VideoSyncController.h VideoSyncController.cpp
+    DeadlineQueue.h DeadlineQueue.cpp
     YamlConfig.h YamlConfig.cpp
 )
 if(OMATRACK_ENABLE_AUTOTEST_HARNESS)

--- a/src/app/ChannelsWindow.qml
+++ b/src/app/ChannelsWindow.qml
@@ -42,8 +42,14 @@ ApplicationWindow {
         sourceModel: Store.channels
     }
     Connections {
-        function onCursorFracChanged(): void {
+        function onChannelsCursorTick(): void {
+            if (!channelsWindow.visible)
+                return;
             ++channelsWindow.cursorTick;
+        }
+        function onCursorFracChanged(): void {
+            if (!channelsWindow.visible)
+                return;
         }
         function onPluginsChanged(): void {
             channelsWindow.pluginRows = Store.pluginLibrary();

--- a/src/app/DeadlineQueue.cpp
+++ b/src/app/DeadlineQueue.cpp
@@ -1,0 +1,123 @@
+#include "DeadlineQueue.h"
+
+#include <algorithm>
+#include <vector>
+
+DeadlineQueue::DeadlineQueue(QObject* parent) : QObject(parent) {
+    timer_.setSingleShot(true);
+    QObject::connect(&timer_, &QTimer::timeout, this, &DeadlineQueue::pump);
+}
+
+void DeadlineQueue::setAutoPump(bool enabled) {
+    autoPump_ = enabled;
+    if (!autoPump_) {
+        timer_.stop();
+        pumpScheduled_ = false;
+        return;
+    }
+    schedule();
+}
+
+bool DeadlineQueue::sooner(const QDeadlineTimer& a, const QDeadlineTimer& b) {
+    if (a.hasExpired() && !b.hasExpired()) return true;
+    if (!a.hasExpired() && b.hasExpired()) return false;
+    if (a.isForever()) return false;
+    if (b.isForever()) return true;
+    return a.remainingTimeNSecs() < b.remainingTimeNSecs();
+}
+
+void DeadlineQueue::upsert(const QString& key, Priority priority,
+                           QDeadlineTimer deadline, Job job) {
+    if (key.isEmpty() || !job) return;
+    auto it = items_.find(key);
+    if (it != items_.end()) {
+        Item& item = it.value();
+        item.job = std::move(job);
+        if (int(priority) > int(item.priority)) item.priority = priority;
+        if (sooner(deadline, item.deadline)) item.deadline = deadline;
+    } else {
+        Item item;
+        item.key = key;
+        item.priority = priority;
+        item.deadline = deadline;
+        item.job = std::move(job);
+        item.serial = ++serial_;
+        items_.insert(key, std::move(item));
+    }
+    if (pumping_ && deadline.hasExpired()) {
+        pumpAgain_ = true;
+        return;
+    }
+    if (autoPump_ && !pumping_) schedule();
+}
+
+int DeadlineQueue::pump() {
+    pumpScheduled_ = false;
+    if (items_.isEmpty()) return 0;
+    if (pumping_) {
+        pumpAgain_ = true;
+        return 0;
+    }
+    pumping_ = true;
+    int ran = 0;
+    do {
+        pumpAgain_ = false;
+        std::vector<Item> due;
+        due.reserve(size_t(items_.size()));
+        for (auto it = items_.begin(); it != items_.end();) {
+            if (it->deadline.hasExpired()) {
+                due.push_back(std::move(it.value()));
+                it = items_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        std::sort(due.begin(), due.end(), [](const Item& a, const Item& b) {
+            if (a.priority != b.priority)
+                return int(a.priority) > int(b.priority);
+            return a.serial < b.serial;
+        });
+        for (Item& item : due) {
+            if (item.job) item.job();
+            ++ran;
+        }
+    } while (pumpAgain_);
+    pumping_ = false;
+    if (autoPump_) schedule();
+    return ran;
+}
+
+void DeadlineQueue::schedule() {
+    if (!autoPump_ || pumping_ || items_.isEmpty()) {
+        timer_.stop();
+        return;
+    }
+    bool anyDue = false;
+    qint64 minRemainNs = -1;
+    for (const Item& item : items_) {
+        if (item.deadline.hasExpired()) {
+            anyDue = true;
+            break;
+        }
+        if (item.deadline.isForever()) continue;
+        const qint64 ns = item.deadline.remainingTimeNSecs();
+        if (ns <= 0) {
+            anyDue = true;
+            break;
+        }
+        if (minRemainNs < 0 || ns < minRemainNs) minRemainNs = ns;
+    }
+    if (anyDue) {
+        if (!pumpScheduled_) {
+            pumpScheduled_ = true;
+            QTimer::singleShot(0, this, [this]() {
+                pumpScheduled_ = false;
+                pump();
+            });
+        }
+        return;
+    }
+    if (minRemainNs < 0) return;
+    const int ms = int(std::max<qint64>(1, (minRemainNs + 999999) / 1000000));
+    timer_.start(ms);
+}

--- a/src/app/DeadlineQueue.h
+++ b/src/app/DeadlineQueue.h
@@ -1,0 +1,65 @@
+// GUI-thread coalescing priority queue with deadlines.
+//
+// Latest-wins per key: a later upsert replaces the pending job for that key
+// and keeps the sooner deadline so a storm cannot push work out forever.
+// Ready items run highest-priority first. The pump is driven by QTimer, never
+// from MpvVideoItem::processEvents / time-pos / wakeup.
+
+#pragma once
+
+#include <QDeadlineTimer>
+#include <QHash>
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+#include <functional>
+
+class DeadlineQueue : public QObject {
+    Q_OBJECT
+
+public:
+    enum class Priority : int { Low = 0, Normal = 1, High = 2 };
+
+    explicit DeadlineQueue(QObject* parent = nullptr);
+
+    using Job = std::function<void()>;
+
+    /// Insert or replace the pending item for `key`. The callable is the
+    /// latest work; an existing sooner deadline is kept; priority is the
+    /// higher of the two.
+    void upsert(const QString& key, Priority priority, QDeadlineTimer deadline,
+                Job job);
+
+    /// Run every currently due item (highest priority first). Empty is a
+    /// no-op. Returns the number of jobs invoked.
+    int pump();
+
+    bool isEmpty() const { return items_.isEmpty(); }
+    int size() const { return items_.size(); }
+
+    /// Tests call pump() themselves. Production leaves auto-pump on so a
+    /// QTimer(0) fires while anything is due, else a single-shot for the
+    /// next deadline.
+    void setAutoPump(bool enabled);
+
+private:
+    struct Item {
+        QString key;
+        Priority priority = Priority::Normal;
+        QDeadlineTimer deadline;
+        Job job;
+        quint64 serial = 0;
+    };
+
+    void schedule();
+    static bool sooner(const QDeadlineTimer& a, const QDeadlineTimer& b);
+
+    QHash<QString, Item> items_;
+    QTimer timer_;
+    quint64 serial_ = 0;
+    bool autoPump_ = true;
+    bool pumping_ = false;
+    bool pumpAgain_ = false;
+    bool pumpScheduled_ = false;
+};

--- a/src/app/Main.qml
+++ b/src/app/Main.qml
@@ -1090,7 +1090,7 @@ ApplicationWindow {
             id: videoTelemetryOverlay
 
             bottomInset: fullscreenFilmstripSlot.visible ? fullscreenFilmstripSlot.height + videoControls.height + 16 : 0
-            mediaTime: videoPlayer.position
+            mediaTime: videoSync.sampledMediaTime
             visible: root.videoFullscreen && root.videoOverlayVisible && root.telemetryVideoActive && videoPlayer.loaded
         }
         VideoDeltaBar {

--- a/src/app/TelemetryStore.cpp
+++ b/src/app/TelemetryStore.cpp
@@ -5617,6 +5617,7 @@ void TelemetryStore::setCursorFrac(double v) {
                                  << primaryVideoTime() << "s";
     }
     emit cursorFracChanged();
+    emit cursorReadoutChanged();
     emit videoTimeChanged();
 }
 
@@ -7494,11 +7495,6 @@ CursorReadout TelemetryStore::cursorReadout() const {
     auto sampleAt = [&](const std::vector<double>& arr, double frac) {
         return omatrack::interpolateFraction(arr, frac);
     };
-    auto sampleQtAt = [&](const QVector<double>& arr, double frac) {
-        if (arr.isEmpty()) return 0.0;
-        return omatrack::interpolateFraction(
-            std::vector<double>(arr.begin(), arr.end()), frac);
-    };
     const double frac = cursorFrac_;
     out.dist = sampleAt(u->distance, frac) -
                (u->distance.empty() ? 0.0 : u->distance.front());
@@ -7511,7 +7507,8 @@ CursorReadout TelemetryStore::cursorReadout() const {
     // Δ vs compare lap (array from the shared cached deltaTrace())
     const QVector<double>& d = deltaTrace();
     if (!d.isEmpty()) {
-        out.delta = sampleQtAt(d, frac);
+        out.delta = omatrack::interpolateFraction(d.constData(),
+                                                  size_t(d.size()), frac);
         out.hasDelta = true;
     }
     return out;

--- a/src/app/TelemetryStore.h
+++ b/src/app/TelemetryStore.h
@@ -800,6 +800,13 @@ public:
     const QVector<CornerZone>& corners() const { return corners_; }
     QString cornerNameAt(double frac) const;
     Q_INVOKABLE CursorReadout cursorReadout() const;
+    /// Header / delta-bar refresh. Video playback emits this from a queued
+    /// deadline job, not from every cursorFracChanged. Pointer/keyboard
+    /// cursor motion still emits it immediately from setCursorFrac().
+    void notifyCursorReadout() { emit cursorReadoutChanged(); }
+    /// Channels window playhead samples. No-op in QML when the window is
+    /// hidden; the video path only enqueues this at a low-priority deadline.
+    void notifyChannelsCursorTick() { emit channelsCursorTick(); }
     /// Accumulated primary−reference time at the cursor station. NaN when
     /// there is no compare lap. Negative is ahead.
     Q_INVOKABLE double cursorTimeDelta() const;
@@ -922,6 +929,8 @@ signals:
     void selectionChanged();
     void editingCornersChanged();
     void cursorFracChanged();
+    void cursorReadoutChanged();
+    void channelsCursorTick();
     void viewChanged();
     void sessionsChanged();
     void cornersChanged();

--- a/src/app/VideoDeltaBar.qml
+++ b/src/app/VideoDeltaBar.qml
@@ -102,7 +102,7 @@ OverlayCard {
         when: !deltaBar.userPositioned
     }
     Connections {
-        function onCursorFracChanged(): void {
+        function onCursorReadoutChanged(): void {
             deltaBar.refresh();
         }
         function onReferenceAlignmentChanged(): void {

--- a/src/app/VideoSyncController.cpp
+++ b/src/app/VideoSyncController.cpp
@@ -3,8 +3,22 @@
 #include "MpvVideoItem.h"
 #include "TelemetryStore.h"
 
+#include <QDeadlineTimer>
+#include <QQuickItem>
+#include <QQuickWindow>
 #include <QUrl>
 #include <QtMath>
+
+#include <chrono>
+
+namespace {
+
+QDeadlineTimer deadlineFrom(bool immediate, std::chrono::milliseconds delay) {
+    if (immediate) return QDeadlineTimer();
+    return QDeadlineTimer(delay);
+}
+
+}  // namespace
 
 VideoSyncController::VideoSyncController(QObject* parent) : QObject(parent) {
     continuousSyncTimer_.setInterval(100);
@@ -35,6 +49,7 @@ void VideoSyncController::setPrimaryPlayer(MpvVideoItem* player) {
     disconnectPrimary();
     primaryPlayer_ = player;
     connectPrimary();
+    attachDisplayPump();
     updateContinuousSyncTimer();
     emit primaryPlayerChanged();
 }
@@ -91,6 +106,9 @@ void VideoSyncController::connectPrimary() {
     primaryPausedConn_ =
         QObject::connect(primaryPlayer_, &MpvVideoItem::pausedChanged, this,
                          &VideoSyncController::onPrimaryPausedChanged);
+    primaryWindowConn_ =
+        QObject::connect(primaryPlayer_, &QQuickItem::windowChanged, this,
+                         [this](QQuickWindow*) { attachDisplayPump(); });
 }
 
 void VideoSyncController::disconnectPrimary() {
@@ -98,6 +116,9 @@ void VideoSyncController::disconnectPrimary() {
     if (primaryPositionConn_) QObject::disconnect(primaryPositionConn_);
     if (primarySeekingConn_) QObject::disconnect(primarySeekingConn_);
     if (primaryPausedConn_) QObject::disconnect(primaryPausedConn_);
+    if (primaryWindowConn_) QObject::disconnect(primaryWindowConn_);
+    if (displayTickConn_) QObject::disconnect(displayTickConn_);
+    displayWindow_.clear();
 }
 
 void VideoSyncController::connectReference() {
@@ -231,7 +252,8 @@ void VideoSyncController::realignPausedVideos() {
         return;
     if (!store_) return;
 
-    store_->setCursorFromVideoTime(primaryPlayer_->position());
+    enqueueTelemetry(true);
+    queue_.pump();
     const double target = store_->compareVideoTime();
     referenceSyncPauseAttempts_ = 0;
     if (target <= 0) {
@@ -262,7 +284,8 @@ void VideoSyncController::verifyPausedVideoAlignment() {
         return;
     }
 
-    store_->setCursorFromVideoTime(primaryPlayer_->position());
+    enqueueTelemetry(true);
+    queue_.pump();
     const double target = store_->compareVideoTime();
     if (target <= 0) {
         setReferenceSyncState(QStringLiteral("NO MAP"));
@@ -335,7 +358,8 @@ void VideoSyncController::seekRelative(double seconds) {
     const double target =
         std::max(0.0, primaryPlayer_->targetPosition() + seconds);
     primaryPlayer_->seek(target);
-    if (telemetryVideoActive_ && store_) store_->setCursorFromVideoTime(target);
+    lastPrimaryMediaTime_ = target;
+    enqueueTelemetry(true);
     if (dualVideo()) syncReferenceVideo(true);
 }
 
@@ -428,20 +452,26 @@ void VideoSyncController::onPrimaryLoadedChanged() {
 
 void VideoSyncController::onPrimaryPositionChanged() {
     if (!primaryPlayer_ || !primaryPlayer_->loaded()) return;
-    if (telemetryVideoActive_ && !primaryPlayer_->paused()) {
-        if (store_) store_->setCursorFromVideoTime(primaryPlayer_->position());
-    } else if (dualVideo() && primaryPlayer_->paused() &&
-               referenceSyncPauseAttempts_ > 0) {
+    lastPrimaryMediaTime_ = primaryPlayer_->position();
+    // Store-only plus a coalesced upsert. The pump (QTimer / afterAnimating)
+    // runs the work; this must not call setCursorFromVideoTime.
+    if (telemetryVideoActive_ && !primaryPlayer_->paused() &&
+        !primaryPlayer_->seeking())
+        enqueueTelemetry(false);
+    else if (dualVideo() && primaryPlayer_->paused() &&
+             referenceSyncPauseAttempts_ > 0)
         pausedAlignmentTimer_.start();
-    }
 }
 
 void VideoSyncController::onPrimarySeekingChanged() {
-    if (primaryPlayer_ && !primaryPlayer_->seeking()) tryResumeLapAdvance();
+    if (!primaryPlayer_) return;
+    if (primaryPlayer_->seeking()) enqueueTelemetry(true);
+    if (!primaryPlayer_->seeking()) tryResumeLapAdvance();
 }
 
 void VideoSyncController::onPrimaryPausedChanged() {
     if (!primaryPlayer_) return;
+    enqueueTelemetry(true);
     if (!referencePlayer_ || !referencePlayer_->loaded()) return;
     if (referencePlayer_->paused() != primaryPlayer_->paused())
         referencePlayer_->setPaused(primaryPlayer_->paused());
@@ -519,4 +549,57 @@ void VideoSyncController::setLapAdvanceCount(int count) {
     if (lapAdvanceCount_ == count) return;
     lapAdvanceCount_ = count;
     emit lapAdvanceCountChanged();
+}
+
+double VideoSyncController::sampledPlayerTime() const {
+    if (!primaryPlayer_) return lastPrimaryMediaTime_;
+    return primaryPlayer_->targetPosition();
+}
+
+void VideoSyncController::applySampledCursor() {
+    if (!primaryPlayer_ || !primaryPlayer_->loaded()) return;
+    const double t = sampledPlayerTime();
+    lastPrimaryMediaTime_ = t;
+    if (!qFuzzyCompare(sampledMediaTime_ + 1.0, t + 1.0)) {
+        sampledMediaTime_ = t;
+        emit sampledMediaTimeChanged();
+    }
+    if (telemetryVideoActive_ && store_) store_->setCursorFromVideoTime(t);
+}
+
+void VideoSyncController::enqueueTelemetry(bool immediate) {
+    if (!telemetryVideoActive_ || !store_) return;
+    queue_.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                  deadlineFrom(immediate, std::chrono::milliseconds(16)),
+                  [this]() { applySampledCursor(); });
+    queue_.upsert(QStringLiteral("readout"), DeadlineQueue::Priority::Normal,
+                  deadlineFrom(immediate, std::chrono::milliseconds(40)),
+                  [this]() {
+                      if (store_) store_->notifyCursorReadout();
+                  });
+    queue_.upsert(QStringLiteral("channels"), DeadlineQueue::Priority::Low,
+                  deadlineFrom(immediate, std::chrono::milliseconds(50)),
+                  [this]() {
+                      if (store_) store_->notifyChannelsCursorTick();
+                  });
+}
+
+void VideoSyncController::attachDisplayPump() {
+    QQuickWindow* window = primaryPlayer_ ? primaryPlayer_->window() : nullptr;
+    if (window == displayWindow_) return;
+    if (displayTickConn_) QObject::disconnect(displayTickConn_);
+    displayWindow_ = window;
+    if (!displayWindow_) return;
+    displayTickConn_ =
+        QObject::connect(displayWindow_, &QQuickWindow::afterAnimating, this,
+                         &VideoSyncController::onDisplayTick);
+}
+
+void VideoSyncController::onDisplayTick() {
+    if (telemetryVideoActive_ && primaryPlayer_ && primaryPlayer_->loaded() &&
+        !primaryPlayer_->paused() && !primaryPlayer_->seeking()) {
+        lastPrimaryMediaTime_ = primaryPlayer_->position();
+        enqueueTelemetry(false);
+    }
+    queue_.pump();
 }

--- a/src/app/VideoSyncController.h
+++ b/src/app/VideoSyncController.h
@@ -9,15 +9,23 @@
 // MpvVideoItem pointers QML assigns after creation. It connects to player and
 // store signals itself, so QML no longer needs nested Connections blocks or
 // hand-rolled Timers for sync.
+//
+// libmpv time-pos only stores the last media time. Overlay, header, traces
+// and channels are enqueued on DeadlineQueue with deadlines and pumped from
+// QTimer / QQuickWindow::afterAnimating — never from processEvents.
 
 #pragma once
 
+#include "DeadlineQueue.h"
+
 #include <QObject>
+#include <QPointer>
 #include <QQmlEngine>
 #include <QString>
 #include <QTimer>
 
 class MpvVideoItem;
+class QQuickWindow;
 class TelemetryStore;
 
 class VideoSyncController : public QObject {
@@ -48,6 +56,8 @@ class VideoSyncController : public QObject {
         int lapAdvanceCount READ lapAdvanceCount NOTIFY lapAdvanceCountChanged)
     Q_PROPERTY(QString lapAdvanceNextLabel READ lapAdvanceNextLabel NOTIFY
                    lapAdvanceCountChanged)
+    Q_PROPERTY(double sampledMediaTime READ sampledMediaTime NOTIFY
+                   sampledMediaTimeChanged)
 
 public:
     explicit VideoSyncController(QObject* parent = nullptr);
@@ -64,6 +74,7 @@ public:
     double referenceSyncBaseRate() const { return referenceSyncBaseRate_; }
     int lapAdvanceCount() const { return lapAdvanceCount_; }
     QString lapAdvanceNextLabel() const { return lapAdvanceNextLabel_; }
+    double sampledMediaTime() const { return sampledMediaTime_; }
 
     void setPrimaryPlayer(MpvVideoItem* player);
     void setReferencePlayer(MpvVideoItem* player);
@@ -90,6 +101,7 @@ signals:
     void dualVideoChanged();
     void referenceSyncStateChanged();
     void lapAdvanceCountChanged();
+    void sampledMediaTimeChanged();
 
 private slots:
     void onPrimaryLoadedChanged();
@@ -106,6 +118,7 @@ private slots:
     void onContinuousSyncTick();
     void onPausedAlignmentTick();
     void onLapAdvanceTick();
+    void onDisplayTick();
 
 private:
     void connectPrimary();
@@ -127,10 +140,15 @@ private:
     void tryResumeLapAdvance();
     void setReferenceSyncState(const QString& state);
     void setLapAdvanceCount(int count);
+    void attachDisplayPump();
+    void enqueueTelemetry(bool immediate);
+    void applySampledCursor();
+    double sampledPlayerTime() const;
 
     MpvVideoItem* primaryPlayer_ = nullptr;
     MpvVideoItem* referencePlayer_ = nullptr;
     TelemetryStore* store_ = nullptr;
+    QPointer<QQuickWindow> displayWindow_;
 
     bool telemetryVideoActive_ = false;
     bool videoFullscreen_ = false;
@@ -142,12 +160,15 @@ private:
     double referenceSyncLastPrimary_ = -1;
     double referenceSyncLastTarget_ = -1;
     int referenceSyncPauseAttempts_ = 0;
+    double sampledMediaTime_ = 0.0;
+    double lastPrimaryMediaTime_ = 0.0;
 
     int lapAdvanceCount_ = 0;
     int lapAdvanceNextId_ = -1;
     QString lapAdvanceNextLabel_;
     bool lapAdvanceResume_ = false;
 
+    DeadlineQueue queue_;
     QTimer continuousSyncTimer_;
     QTimer pausedAlignmentTimer_;
     QTimer lapAdvanceTimer_;
@@ -156,6 +177,8 @@ private:
     QMetaObject::Connection primaryPositionConn_;
     QMetaObject::Connection primarySeekingConn_;
     QMetaObject::Connection primaryPausedConn_;
+    QMetaObject::Connection primaryWindowConn_;
+    QMetaObject::Connection displayTickConn_;
     QMetaObject::Connection referenceLoadedConn_;
     QMetaObject::Connection referencePausedConn_;
     QMetaObject::Connection storeVideoTimeConn_;

--- a/src/app/VideoTelemetryHud.cpp
+++ b/src/app/VideoTelemetryHud.cpp
@@ -253,47 +253,40 @@ QSGNode* VideoTelemetryHud::updatePaintNode(QSGNode* oldNode,
         };
 
         const bool whiteRef = store_ && store_->overlayRefWhite();
-        const QString refStyle =
-            store_ ? store_->overlayRefStyle() : QStringLiteral("dashed");
         const QColor refColor =
             whiteRef ? QColor(Qt::white)
                      : QColor(store_ && !store_->overlayRefColor().isEmpty()
                                   ? store_->overlayRefColor()
                                   : QStringLiteral("#e09d7f"));
         const qreal refWidth = whiteRef ? 2.4 * s : 1.5 * s;
-        auto refDash = TraceSceneBuilder::EnvelopeStyle::Dash::Dashed;
-        if (refStyle == QLatin1String("dotted"))
-            refDash = TraceSceneBuilder::EnvelopeStyle::Dash::Dotted;
-        else if (refStyle == QLatin1String("solid"))
-            refDash = TraceSceneBuilder::EnvelopeStyle::Dash::Solid;
-        const auto drawStyled =
-            [&](const std::vector<double>& values, double maximum,
-                bool reference, qreal width, const QColor& color,
-                TraceSceneBuilder::EnvelopeStyle::Dash dash) {
-                if (values.size() < 2 || !primary || primary->size() < 2 ||
-                    maximum <= 0.0)
-                    return;
-                auto sourceFraction = [&](double viewportFrac) -> double {
-                    const double pf = std::clamp(viewportFrac, 0.0, 1.0);
-                    return reference
-                               ? snapshot_.compareFractionForPrimaryFraction(pf)
-                               : pf;
-                };
-                TraceSceneBuilder::EnvelopeStyle style;
-                style.width = width;
-                style.color = color;
-                style.dash = dash;
-                builder_.envelopePolyline(values, sourceFraction, windowStart,
-                                          kWindowFrac, graphRect, 0.0, maximum,
-                                          style, 0.0, 1.0);
+        // Video HUD rebuilds a 10% scrolling window every frame. Dashed
+        // envelopePolyline flushes a polyline per gap, exploding QSG nodes
+        // at display rate. Style still applies on TraceView (invalidateScene).
+        const auto drawStyled = [&](const std::vector<double>& values,
+                                    double maximum, bool reference, qreal width,
+                                    const QColor& color) {
+            if (values.size() < 2 || !primary || primary->size() < 2 ||
+                maximum <= 0.0)
+                return;
+            auto sourceFraction = [&](double viewportFrac) -> double {
+                const double pf = std::clamp(viewportFrac, 0.0, 1.0);
+                return reference
+                           ? snapshot_.compareFractionForPrimaryFraction(pf)
+                           : pf;
             };
+            TraceSceneBuilder::EnvelopeStyle style;
+            style.width = width;
+            style.color = color;
+            style.dash = TraceSceneBuilder::EnvelopeStyle::Dash::Solid;
+            builder_.envelopePolyline(values, sourceFraction, windowStart,
+                                      kWindowFrac, graphRect, 0.0, maximum,
+                                      style, 0.0, 1.0);
+        };
         if (compare) {
             drawStyled(compare->throttle, 1.0, true, refWidth,
-                       withAlpha(whiteRef ? QColor(Qt::white) : refColor, 200),
-                       refDash);
+                       withAlpha(whiteRef ? QColor(Qt::white) : refColor, 200));
             drawStyled(compare->brake, brakeMax, true, refWidth,
-                       withAlpha(whiteRef ? QColor(Qt::white) : refColor, 200),
-                       refDash);
+                       withAlpha(whiteRef ? QColor(Qt::white) : refColor, 200));
         }
         drawTrace(primaryThrottle, throttleScale, false, 2.5 * s,
                   throttleColor_);

--- a/src/core/MonotonicSeries.h
+++ b/src/core/MonotonicSeries.h
@@ -62,24 +62,27 @@ struct MonotonicView {
 /// Clamps to the endpoints. Returns y[0] (or 0) for degenerate inputs.
 inline double interpolate(const std::vector<double>& x,
                           const std::vector<double>& y, double xq) {
-    if (x.size() != y.size() || x.size() < 2)
-        return y.empty() ? 0.0 : y[0];
+    if (x.size() != y.size() || x.size() < 2) return y.empty() ? 0.0 : y[0];
     MonotonicView view{x.data(), y.data(), x.size()};
     return view.at(xq);
 }
 
-/// Interpolate a uniformly-spaced y vector at fractional position [0,1].
+/// Interpolate a uniformly-spaced y array at fractional position [0,1].
 /// Equivalent to MonotonicView over x=[0,1,...,n-1], y=data,
-/// query=fraction*(n-1). Clamps fraction to [0,1].
+/// query=fraction*(n-1). Clamps fraction to [0,1]. Does not allocate.
+inline double interpolateFraction(const double* y, size_t n, double fraction) {
+    if (!y || n == 0) return 0.0;
+    if (n == 1) return y[0];
+    fraction = std::clamp(fraction, 0.0, 1.0);
+    const double position = fraction * double(n - 1);
+    const size_t lo = size_t(std::floor(position));
+    const size_t hi = std::min(lo + 1, n - 1);
+    return y[lo] + (y[hi] - y[lo]) * (position - double(lo));
+}
+
 inline double interpolateFraction(const std::vector<double>& y,
                                   double fraction) {
-    if (y.empty()) return 0.0;
-    if (y.size() == 1) return y[0];
-    fraction = std::clamp(fraction, 0.0, 1.0);
-    const double position = fraction * double(y.size() - 1);
-    const size_t lo = size_t(std::floor(position));
-    const size_t hi = std::min(lo + 1, y.size() - 1);
-    return y[lo] + (y[hi] - y[lo]) * (position - double(lo));
+    return interpolateFraction(y.data(), y.size(), fraction);
 }
 
 /// Inverse of interpolateFraction: given a y value, return the fraction

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -231,6 +231,15 @@ target_link_libraries(overlay-style-test PRIVATE
 add_test(NAME overlay-style-test COMMAND overlay-style-test)
 set_tests_properties(overlay-style-test PROPERTIES LABELS unit)
 
+qt_add_executable(deadline-queue-test DeadlineQueueTest.cpp
+  ${CMAKE_SOURCE_DIR}/src/app/DeadlineQueue.cpp)
+target_include_directories(deadline-queue-test PRIVATE
+  ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(deadline-queue-test PRIVATE
+  Qt6::Test Qt6::Core omatrack_warnings)
+add_test(NAME deadline-queue-test COMMAND deadline-queue-test)
+set_tests_properties(deadline-queue-test PROPERTIES LABELS unit)
+
 qt_add_executable(swap-roles-test SwapRolesTest.cpp)
 target_include_directories(swap-roles-test PRIVATE
   ${CMAKE_SOURCE_DIR}/src)

--- a/tests/CoreTest.cpp
+++ b/tests/CoreTest.cpp
@@ -1921,6 +1921,16 @@ private slots:
         QVERIFY(std::abs(interpolateFraction(y, 0.25) - 7.5) < 1e-9);
     }
 
+    void interpolateFractionPointerSpan() {
+        const double y[] = {0.0, 10.0, 20.0, 30.0};
+        QCOMPARE(interpolateFraction(y, 4, 0.0), 0.0);
+        QCOMPARE(interpolateFraction(y, 4, 1.0), 30.0);
+        QVERIFY(std::abs(interpolateFraction(y, 4, 0.5) - 15.0) < 1e-9);
+        QCOMPARE(
+            interpolateFraction(static_cast<const double*>(nullptr), 0, 0.5),
+            0.0);
+    }
+
     void interpolateFractionClamps() {
         const std::vector<double> y{0.0, 10.0, 20.0};
         QCOMPARE(interpolateFraction(y, -0.5), 0.0);

--- a/tests/DeadlineQueueTest.cpp
+++ b/tests/DeadlineQueueTest.cpp
@@ -1,0 +1,93 @@
+#include "app/DeadlineQueue.h"
+
+#include <QTest>
+
+#include <chrono>
+
+class DeadlineQueueTest : public QObject {
+    Q_OBJECT
+private slots:
+    void upsertCoalescesToLatest() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        int value = 0;
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(), [&]() { value = 1; });
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(), [&]() { value = 2; });
+        QCOMPARE(queue.size(), 1);
+        QCOMPARE(queue.pump(), 1);
+        QCOMPARE(value, 2);
+        QVERIFY(queue.isEmpty());
+    }
+
+    void higherPriorityRunsFirstAmongDue() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        QString order;
+        queue.upsert(QStringLiteral("low"), DeadlineQueue::Priority::Low,
+                     QDeadlineTimer(), [&]() { order += QLatin1Char('L'); });
+        queue.upsert(QStringLiteral("high"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(), [&]() { order += QLatin1Char('H'); });
+        queue.upsert(QStringLiteral("normal"), DeadlineQueue::Priority::Normal,
+                     QDeadlineTimer(), [&]() { order += QLatin1Char('N'); });
+        QCOMPARE(queue.pump(), 3);
+        QCOMPARE(order, QStringLiteral("HNL"));
+    }
+
+    void overdueKeepsLatestWins() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        int runs = 0;
+        int value = 0;
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(), [&]() {
+                         ++runs;
+                         value = 1;
+                     });
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(), [&]() {
+                         ++runs;
+                         value = 2;
+                     });
+        QCOMPARE(queue.pump(), 1);
+        QCOMPARE(runs, 1);
+        QCOMPARE(value, 2);
+    }
+
+    void emptyPumpIsNoOp() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        QCOMPARE(queue.pump(), 0);
+        QVERIFY(queue.isEmpty());
+    }
+
+    void futureDeadlineIsNotRun() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        bool ran = false;
+        queue.upsert(QStringLiteral("later"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(std::chrono::hours(1)),
+                     [&]() { ran = true; });
+        QCOMPARE(queue.pump(), 0);
+        QVERIFY(!ran);
+        QCOMPARE(queue.size(), 1);
+    }
+
+    void coalesceKeepsSoonerDeadline() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        int value = 0;
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(), [&]() { value = 1; });
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(std::chrono::hours(1)),
+                     [&]() { value = 2; });
+        QCOMPARE(queue.pump(), 1);
+        QCOMPARE(value, 2);
+        QVERIFY(queue.isEmpty());
+    }
+};
+
+QTEST_GUILESS_MAIN(DeadlineQueueTest)
+#include "DeadlineQueueTest.moc"


### PR DESCRIPTION
## Summary
- Video publishes position only. Overlay, header, traces and channels sample it through a coalescing deadline-able priority queue (`DeadlineQueue`) pumped from `QTimer` / `afterAnimating`, never from libmpv `time-pos`.
- Header/delta at ~40ms, channels at ~50ms and only when that window is visible. HUD ref traces stay solid so dash does not explode QSG nodes every frame. `cursorReadout` interpolates the delta vector in place.
- Version 1.7.1.

## Test plan
- [ ] Play an onboard on a Windows laptop with overlay HUD + compare lap: video stays smooth, cursor/HUD still track.
- [ ] Seek/pause/scrub still snaps telemetry immediately.
- [ ] Channels window values update while open, not while closed.
- [ ] Overlay dash/dot prefs still apply on the main trace view.
- [ ] `deadline-queue-test` and `core-test` in CI.