### PR TITLE
1.7.2: corner drag on overlay, sample video playhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,10 @@ Interactive rendering targets 60–120 fps. A frame is 16.67 ms at 60 Hz and 8.3
 - Cache normalized laps, raw-channel resamples, delta arrays, geometry, and overview rasters; invalidate them only when their inputs change.
 - Bound draw work to the viewport and pixel budget. Do not submit every source sample when fewer points can produce the same image.
 - Avoid per-frame heap allocation and avoid copies of full telemetry arrays.
-  libmpv `time-pos` must not fan out into store/HUD/header/trace work; enqueue
-  it on `DeadlineQueue` and pump independently of the player callback.
+  libmpv `time-pos` must not fan out into store/HUD/header/trace work; sample
+  it on a timer onto `DeadlineQueue` and pump independently of the player
+  callback. Corner drag/hover stays on the overlay path: do not rebuild
+  static traces, comparison alignment, or emit `videoTimeChanged` per pixel.
 - Benchmark hover and zoom paths before and after renderer changes. A visually correct regression that misses the frame budget is not complete.
 
 ### Native Linux and Omarchy are deliberate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable user-facing changes are documented here.
 
+## 1.7.2 — 2026-09-02
+
+- Corner drag and hover stay on the cursor overlay. Live geometry no longer
+  rebuilds static traces, comparison alignment, the corners inspector, or
+  video time on every mouse move. Alignment and inspector stats commit when
+  the edit is saved.
+- Video playhead is sampled on an 80 ms timer, not libmpv `time-pos`. QML
+  binds `sampledMediaTime`. HUD and trace overlay are separate deadline-queue
+  keys. USB, import, plugins, filmstrip and event mode are unchanged.
+
 ## 1.7.1 — 2026-09-02
 
 - Video publishes its position; overlay, header and traces sample it through

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(omatrack VERSION 1.7.1 LANGUAGES CXX)
+project(omatrack VERSION 1.7.2 LANGUAGES CXX)
 if(WIN32)
   # Windows release layout: the app ships as a flat zip, so executables and
   # their load-time DLLs install at the prefix root and every non-binary

--- a/src/app/DeadlineQueue.h
+++ b/src/app/DeadlineQueue.h
@@ -37,6 +37,9 @@ public:
 
     bool isEmpty() const { return items_.isEmpty(); }
     int size() const { return items_.size(); }
+    /// True while a job for key is waiting. Callers that would only
+    /// replace it with an equivalent latest-spot reader skip allocating.
+    bool contains(const QString& key) const { return items_.contains(key); }
 
     /// Tests call pump() themselves. Production leaves auto-pump on so a
     /// QTimer(0) fires while anything is due, else a single-shot for the

--- a/src/app/Main.qml
+++ b/src/app/Main.qml
@@ -884,6 +884,7 @@ ApplicationWindow {
 
             HoverHandler {
                 id: videoControlsHover
+
             }
             MouseArea {
                 anchors.fill: parent
@@ -904,7 +905,7 @@ ApplicationWindow {
                     objectName: "videoSeekSlider"
                     stepSize: 0.1
                     to: Math.max(0.1, videoPlayer.duration)
-                    value: videoPlayer.position
+                    value: videoSync.sampledMediaTime
                     visible: root.standaloneVideoActive
 
                     background: Rectangle {
@@ -1050,7 +1051,7 @@ ApplicationWindow {
                         color: Style.foregroundColor
                         font.family: Style.monoFontFamily
                         font.pixelSize: Style.smallFontSize
-                        text: root.formatMediaTime(videoPlayer.position) + " / " + root.formatMediaTime(videoPlayer.duration)
+                        text: root.formatMediaTime(videoSync.sampledMediaTime) + " / " + root.formatMediaTime(videoPlayer.duration)
                     }
                     Item {
                         Layout.fillWidth: !root.standaloneVideoActive
@@ -1359,9 +1360,11 @@ ApplicationWindow {
     }
     ChannelsWindow {
         id: channelsWindow
+
     }
     PreferencesWindow {
         id: settingsWindow
+
     }
     ToolTip {
         id: pointerTooltip

--- a/src/app/MpvVideoItem.cpp
+++ b/src/app/MpvVideoItem.cpp
@@ -165,7 +165,9 @@ private:
     }
 
     void requestUpdate() {
-        if (item_)
+        if (!item_) return;
+        bool expected = false;
+        if (item_->frameRequested_.compare_exchange_strong(expected, true))
             QMetaObject::invokeMethod(item_, "requestVideoFrame",
                                       Qt::QueuedConnection);
     }
@@ -239,7 +241,6 @@ MpvVideoItem::MpvVideoItem(QQuickItem* parent)
     // account needed when a load stalls or a seek lands on the wrong frame.
     mpv_request_log_messages(state_->handle,
                              omatrack::isVerbose() ? "info" : "warn");
-    mpv_observe_property(state_->handle, 1, "time-pos", MPV_FORMAT_DOUBLE);
     mpv_observe_property(state_->handle, 2, "duration", MPV_FORMAT_DOUBLE);
     mpv_observe_property(state_->handle, 3, "pause", MPV_FORMAT_FLAG);
     mpv_observe_property(state_->handle, 4, "mute", MPV_FORMAT_FLAG);
@@ -261,6 +262,16 @@ MpvVideoItem::~MpvVideoItem() {
 
 QQuickFramebufferObject::Renderer* MpvVideoItem::createRenderer() const {
     return new MpvVideoRenderer(state_, const_cast<MpvVideoItem*>(this));
+}
+
+double MpvVideoItem::position() const {
+    if (state_ && state_->handle) {
+        double value = 0.0;
+        if (mpv_get_property(state_->handle, "time-pos", MPV_FORMAT_DOUBLE,
+                             &value) >= 0)
+            position_ = std::max(0.0, value);
+    }
+    return position_;
 }
 
 void MpvVideoItem::wakeup(void* context) {
@@ -336,15 +347,8 @@ void MpvVideoItem::processEvents() {
                 const auto* property =
                     static_cast<mpv_event_property*>(event->data);
                 if (!property || !property->name || !property->data) break;
-                if (std::strcmp(property->name, "time-pos") == 0 &&
+                if (std::strcmp(property->name, "duration") == 0 &&
                     property->format == MPV_FORMAT_DOUBLE) {
-                    const double value = *static_cast<double*>(property->data);
-                    if (!qFuzzyCompare(position_ + 1.0, value + 1.0)) {
-                        position_ = std::max(0.0, value);
-                        emit positionChanged();
-                    }
-                } else if (std::strcmp(property->name, "duration") == 0 &&
-                           property->format == MPV_FORMAT_DOUBLE) {
                     const double value = *static_cast<double*>(property->data);
                     if (!qFuzzyCompare(duration_ + 1.0, value + 1.0)) {
                         duration_ = std::max(0.0, value);
@@ -439,7 +443,10 @@ void MpvVideoItem::setDisplaySize(qint64 width, qint64 height) {
     emit videoAspectRatioChanged();
 }
 
-void MpvVideoItem::requestVideoFrame() { update(); }
+void MpvVideoItem::requestVideoFrame() {
+    frameRequested_.store(false);
+    update();
+}
 
 void MpvVideoItem::markRendererReady() {
     if (ready_) return;

--- a/src/app/MpvVideoItem.h
+++ b/src/app/MpvVideoItem.h
@@ -9,6 +9,7 @@
 #include <QtQml/qqmlregistration.h>
 #include <QUrl>
 
+#include <atomic>
 #include <memory>
 #include <optional>
 
@@ -45,7 +46,7 @@ public:
     bool paused() const { return paused_; }
     bool muted() const { return muted_; }
     bool seeking() const { return seeking_; }
-    double position() const { return position_; }
+    double position() const;
     /// Where the playhead is, or is about to be: the target of an exact seek
     /// mpv has not finished yet, else the last reported position. Relative
     /// skips must start from this — an exact seek into a multi-gigabyte
@@ -125,7 +126,8 @@ private:
     QUrl pendingSource_;
     QString title_;
     QString errorString_;
-    double position_ = 0.0;
+    mutable double position_ = 0.0;
+    std::atomic<bool> frameRequested_{false};
     double duration_ = 0.0;
     qint64 displayWidth_ = 0;
     qint64 displayHeight_ = 0;

--- a/src/app/StoreModels.cpp
+++ b/src/app/StoreModels.cpp
@@ -1,6 +1,7 @@
 #include "StoreModels.h"
 
 #include <QString>
+#include <QtGlobal>
 #include <algorithm>
 
 int UsbCopyListModel::rowCount(const QModelIndex& parent) const {
@@ -344,6 +345,18 @@ QHash<int, QByteArray> CornerListModel::roleNames() const {
         {NotesRole, "notes"},
         {NoteRole, "note"},
     };
+}
+
+void CornerListModel::updateGeometry(int index, double start, double end) {
+    if (index < 0 || index >= rows_.size()) return;
+    CornerRow& row = rows_[index];
+    if (qFuzzyCompare(row.start + 1.0, start + 1.0) &&
+        qFuzzyCompare(row.end + 1.0, end + 1.0))
+        return;
+    row.start = start;
+    row.end = end;
+    const QModelIndex idx = this->index(index);
+    emit dataChanged(idx, idx, {StartRole, EndRole});
 }
 
 void CornerListModel::refresh(const QVector<CornerRow>& rows) {

--- a/src/app/StoreModels.h
+++ b/src/app/StoreModels.h
@@ -226,6 +226,8 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     void refresh(const QVector<CornerRow>& rows);
+    /// Live drag: update start/end in place without rebuilding rows.
+    void updateGeometry(int index, double start, double end);
 
 private:
     QVector<CornerRow> rows_;

--- a/src/app/TelemetryStore.cpp
+++ b/src/app/TelemetryStore.cpp
@@ -2504,10 +2504,11 @@ TelemetryStore::TelemetryStore(QObject* parent)
     // longer contains the focused zone drops the focus, and a new lap
     // selection recomputes its markers.
     connect(this, &TelemetryStore::cornersChanged, this, [this]() {
+        // Structural add/delete/load/commit only. Live drag uses
+        // cornerGeometryChanged and must not rebuild alignment, seek
+        // video, or fan cursorFracChanged per pixel.
         invalidateComparisonAlignment();
         rebuildComparisonAlignment();
-        emit cursorFracChanged();
-        emit videoTimeChanged();
         if (focusedCorner_ < 0) return;
         if (focusedCorner_ >= corners_.size())
             clearCornerFocus();
@@ -5840,7 +5841,8 @@ void TelemetryStore::setCursorFromVideoTime(double mediaTime) {
             return;
         }
         cursorFrac_ = fraction;
-        emit cursorFracChanged();
+        // Video path: HUD and traces overlay sample via deadline-queue keys,
+        // not this signal. Pointer/keyboard still emit from setCursorFrac().
         if (fraction >= 0.999 && !wasAtEnd) emit primaryLapPlaybackEnded();
         return;
     }
@@ -5974,7 +5976,10 @@ void TelemetryStore::autoGenerateCorners() {
 }
 
 void TelemetryStore::saveCorners() {
-    if (!primarySession_) return;
+    if (!primarySession_) {
+        emit cornersChanged();
+        return;
+    }
     auto sorted = corners_;
     std::sort(sorted.begin(), sorted.end(),
               [](const CornerZone& a, const CornerZone& b) {
@@ -5993,6 +5998,7 @@ void TelemetryStore::saveCorners() {
         assignedSlug.isEmpty() ? primarySession_->track() : assignedSlug;
     config.setValue(cornerConfigPath(cornerTrack), zones);
     schedulePreferencesSave();
+    emit cornersChanged();
 }
 
 QString TelemetryStore::cornerName(int index) const {
@@ -6949,7 +6955,6 @@ int TelemetryStore::addCorner(double start, double end) {
                                            return candidate.name == corner.name;
                                        }) -
                           corners_.cbegin());
-    emit cornersChanged();
     saveCorners();
     return index;
 }
@@ -6957,7 +6962,6 @@ int TelemetryStore::addCorner(double start, double end) {
 void TelemetryStore::deleteCorner(int index) {
     if (index < 0 || index >= corners_.size()) return;
     corners_.removeAt(index);
-    emit cornersChanged();
     saveCorners();
 }
 
@@ -6969,7 +6973,6 @@ void TelemetryStore::setCornerName(int index, const QString& name) {
     QString sanitized = trimmed;
     sanitized.replace('\r', ' ').replace('\n', ' ');
     corners_[index].name = sanitized;
-    emit cornersChanged();
     saveCorners();
 }
 
@@ -6982,8 +6985,8 @@ void TelemetryStore::updateCorner(int index, double start, double end) {
         return;
     corners_[index].start = nextStart;
     corners_[index].end = nextEnd;
-    emit cornersChanged();
-    if (index == focusedCorner_) rebuildCornerMarkers();
+    if (cornersModel_) cornersModel_->updateGeometry(index, nextStart, nextEnd);
+    emit cornerGeometryChanged();
 }
 
 void TelemetryStore::setEditingCorners(bool editing) {

--- a/src/app/TelemetryStore.h
+++ b/src/app/TelemetryStore.h
@@ -807,6 +807,11 @@ public:
     /// Channels window playhead samples. No-op in QML when the window is
     /// hidden; the video path only enqueues this at a low-priority deadline.
     void notifyChannelsCursorTick() { emit channelsCursorTick(); }
+    /// Video HUD paint. Separate from cursorFracChanged so playhead
+    /// sampling does not retrace the HUD at mpv rate.
+    void notifyHudCursor() { emit hudCursorTick(); }
+    /// Trace cursor overlay paint. Same split: video samples this key.
+    void notifyTraceOverlay() { emit overlayCursorTick(); }
     /// Accumulated primary−reference time at the cursor station. NaN when
     /// there is no compare lap. Negative is ahead.
     Q_INVOKABLE double cursorTimeDelta() const;
@@ -931,9 +936,13 @@ signals:
     void cursorFracChanged();
     void cursorReadoutChanged();
     void channelsCursorTick();
+    void hudCursorTick();
+    void overlayCursorTick();
     void viewChanged();
     void sessionsChanged();
     void cornersChanged();
+    /// Live corner drag/hover geometry. Overlay only; not a full model rebuild.
+    void cornerGeometryChanged();
     void cornerFocusChanged();
     void highlightedCornerMarkerChanged();
     void cornerConsistencyChanged();

--- a/src/app/TraceView.cpp
+++ b/src/app/TraceView.cpp
@@ -161,15 +161,19 @@ void TraceView::setStore(TelemetryStore* store) {
         });
         connect(store_, &TelemetryStore::cursorFracChanged, this,
                 [this]() { emit overlayChanged(); });
+        connect(store_, &TelemetryStore::overlayCursorTick, this,
+                [this]() { emit overlayChanged(); });
+        connect(store_, &TelemetryStore::cornerGeometryChanged, this,
+                [this]() { emit overlayChanged(); });
         connect(store_, &TelemetryStore::viewChanged, this,
                 &TraceView::invalidateScene);
         connect(store_, &TelemetryStore::cornersChanged, this,
-                &TraceView::invalidateScene);
+                [this]() { emit overlayChanged(); });
         connect(store_, &TelemetryStore::editingCornersChanged, this,
-                &TraceView::invalidateScene);
+                [this]() { emit overlayChanged(); });
         connect(store_, &TelemetryStore::cornerFocusChanged, this, [this]() {
             interaction_.resetHover();
-            invalidateScene();
+            emit overlayChanged();
         });
         connect(store_, &TelemetryStore::highlightedCornerMarkerChanged, this,
                 [this]() { emit overlayChanged(); });
@@ -337,8 +341,6 @@ void TraceView::buildScene(TraceSceneBuilder& builder) {
     const double traceHeight = std::max(0.0, height() - kTopPad - kBottomPad);
     const QRectF traceRect(labelWidth(), kTopPad, width() - labelWidth(),
                            traceHeight);
-    buildCornerZones(builder, traceRect);
-    buildCornerFocus(builder, traceRect);
     buildOutOfLap(builder, traceRect);
 
     setCursorTop(kTopPad - 3);
@@ -838,9 +840,9 @@ void TraceView::buildDelta(TraceSceneBuilder& builder, const QRectF& rect) {
 
 void TraceView::buildCornerZones(TraceSceneBuilder& builder,
                                  const QRectF& totalRect) {
-    if (!store_ || snapshot_.corners->isEmpty()) return;
+    if (!store_ || store_->corners().isEmpty()) return;
     const bool editing = store_->editingCorners();
-    const auto& corners = *snapshot_.corners;
+    const auto& corners = store_->corners();
     for (const CornerZone& corner : corners) {
         const double x1 = xForFrac(corner.start);
         const double x2 = xForFrac(corner.end);
@@ -879,8 +881,8 @@ void TraceView::buildCornerFocus(TraceSceneBuilder& builder,
                                  const QRectF& totalRect) {
     if (!store_) return;
     const int focused = store_->focusedCorner();
-    if (focused < 0 || focused >= snapshot_.corners->size()) return;
-    const CornerZone& corner = (*snapshot_.corners)[focused];
+    if (focused < 0 || focused >= store_->corners().size()) return;
+    const CornerZone& corner = store_->corners()[focused];
     const double x1 =
         std::clamp(xForFrac(corner.start), totalRect.left(), totalRect.right());
     const double x2 =
@@ -1051,6 +1053,11 @@ void TraceView::buildCursorScene(TraceSceneBuilder& builder) {
         }
     }
 
+    const double traceHeight = std::max(0.0, height() - kTopPad - kBottomPad);
+    const QRectF traceRect(labelWidth(), kTopPad, width() - labelWidth(),
+                           traceHeight);
+    buildCornerZones(builder, traceRect);
+    buildCornerFocus(builder, traceRect);
     buildCornerMarkers(builder);
     buildHoveredCornerDelta(builder);
 }
@@ -1123,7 +1130,7 @@ void TraceView::buildSelection(TraceSceneBuilder& builder) {
 void TraceView::buildHoveredCornerDelta(TraceSceneBuilder& builder) {
     if (!store_ || !store_->comparing() || interaction_.hoveredCorner() < 0)
         return;
-    const auto& corners = *snapshot_.corners;
+    const auto& corners = store_->corners();
     if (interaction_.hoveredCorner() >= corners.size()) return;
     const QVector<double>& delta = *snapshot_.deltaTrace;
     if (delta.size() < 2) return;

--- a/src/app/VideoSyncController.cpp
+++ b/src/app/VideoSyncController.cpp
@@ -10,6 +10,7 @@
 #include <QtMath>
 
 #include <chrono>
+#include <utility>
 
 namespace {
 
@@ -33,6 +34,10 @@ VideoSyncController::VideoSyncController(QObject* parent) : QObject(parent) {
     lapAdvanceTimer_.setInterval(500);
     QObject::connect(&lapAdvanceTimer_, &QTimer::timeout, this,
                      &VideoSyncController::onLapAdvanceTick);
+
+    sampleTimer_.setInterval(80);
+    QObject::connect(&sampleTimer_, &QTimer::timeout, this,
+                     &VideoSyncController::onSampleTick);
 }
 
 // ── properties ───────────────────────────────────────────────────
@@ -51,6 +56,7 @@ void VideoSyncController::setPrimaryPlayer(MpvVideoItem* player) {
     connectPrimary();
     attachDisplayPump();
     updateContinuousSyncTimer();
+    updateSampleTimer();
     emit primaryPlayerChanged();
 }
 
@@ -97,9 +103,6 @@ void VideoSyncController::connectPrimary() {
     primaryLoadedConn_ =
         QObject::connect(primaryPlayer_, &MpvVideoItem::loadedChanged, this,
                          &VideoSyncController::onPrimaryLoadedChanged);
-    primaryPositionConn_ =
-        QObject::connect(primaryPlayer_, &MpvVideoItem::positionChanged, this,
-                         &VideoSyncController::onPrimaryPositionChanged);
     primarySeekingConn_ =
         QObject::connect(primaryPlayer_, &MpvVideoItem::seekingChanged, this,
                          &VideoSyncController::onPrimarySeekingChanged);
@@ -113,7 +116,6 @@ void VideoSyncController::connectPrimary() {
 
 void VideoSyncController::disconnectPrimary() {
     if (primaryLoadedConn_) QObject::disconnect(primaryLoadedConn_);
-    if (primaryPositionConn_) QObject::disconnect(primaryPositionConn_);
     if (primarySeekingConn_) QObject::disconnect(primarySeekingConn_);
     if (primaryPausedConn_) QObject::disconnect(primaryPausedConn_);
     if (primaryWindowConn_) QObject::disconnect(primaryWindowConn_);
@@ -436,6 +438,7 @@ void VideoSyncController::tryResumeLapAdvance() {
 // ── signal handlers ──────────────────────────────────────────────
 
 void VideoSyncController::onPrimaryLoadedChanged() {
+    updateSampleTimer();
     if (!primaryPlayer_ || !primaryPlayer_->loaded() || !telemetryVideoActive_)
         return;
     // Qt.callLater equivalent: defer until the next event-loop turn so the
@@ -450,19 +453,6 @@ void VideoSyncController::onPrimaryLoadedChanged() {
         Qt::QueuedConnection);
 }
 
-void VideoSyncController::onPrimaryPositionChanged() {
-    if (!primaryPlayer_ || !primaryPlayer_->loaded()) return;
-    lastPrimaryMediaTime_ = primaryPlayer_->position();
-    // Store-only plus a coalesced upsert. The pump (QTimer / afterAnimating)
-    // runs the work; this must not call setCursorFromVideoTime.
-    if (telemetryVideoActive_ && !primaryPlayer_->paused() &&
-        !primaryPlayer_->seeking())
-        enqueueTelemetry(false);
-    else if (dualVideo() && primaryPlayer_->paused() &&
-             referenceSyncPauseAttempts_ > 0)
-        pausedAlignmentTimer_.start();
-}
-
 void VideoSyncController::onPrimarySeekingChanged() {
     if (!primaryPlayer_) return;
     if (primaryPlayer_->seeking()) enqueueTelemetry(true);
@@ -471,6 +461,7 @@ void VideoSyncController::onPrimarySeekingChanged() {
 
 void VideoSyncController::onPrimaryPausedChanged() {
     if (!primaryPlayer_) return;
+    updateSampleTimer();
     enqueueTelemetry(true);
     if (!referencePlayer_ || !referencePlayer_->loaded()) return;
     if (referencePlayer_->paused() != primaryPlayer_->paused())
@@ -568,20 +559,34 @@ void VideoSyncController::applySampledCursor() {
 }
 
 void VideoSyncController::enqueueTelemetry(bool immediate) {
+    const auto tryUpsert = [this, immediate](const QString& key,
+                                             DeadlineQueue::Priority priority,
+                                             std::chrono::milliseconds delay,
+                                             DeadlineQueue::Job job) {
+        if (!immediate && queue_.contains(key)) return;
+        queue_.upsert(key, priority, deadlineFrom(immediate, delay),
+                      std::move(job));
+    };
+    tryUpsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+              std::chrono::milliseconds(16),
+              [this]() { applySampledCursor(); });
     if (!telemetryVideoActive_ || !store_) return;
-    queue_.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
-                  deadlineFrom(immediate, std::chrono::milliseconds(16)),
-                  [this]() { applySampledCursor(); });
-    queue_.upsert(QStringLiteral("readout"), DeadlineQueue::Priority::Normal,
-                  deadlineFrom(immediate, std::chrono::milliseconds(40)),
-                  [this]() {
-                      if (store_) store_->notifyCursorReadout();
-                  });
-    queue_.upsert(QStringLiteral("channels"), DeadlineQueue::Priority::Low,
-                  deadlineFrom(immediate, std::chrono::milliseconds(50)),
-                  [this]() {
-                      if (store_) store_->notifyChannelsCursorTick();
-                  });
+    tryUpsert(QStringLiteral("hud"), DeadlineQueue::Priority::Normal,
+              std::chrono::milliseconds(64), [this]() {
+                  if (store_) store_->notifyHudCursor();
+              });
+    tryUpsert(QStringLiteral("traces"), DeadlineQueue::Priority::Normal,
+              std::chrono::milliseconds(64), [this]() {
+                  if (store_) store_->notifyTraceOverlay();
+              });
+    tryUpsert(QStringLiteral("readout"), DeadlineQueue::Priority::Normal,
+              std::chrono::milliseconds(40), [this]() {
+                  if (store_) store_->notifyCursorReadout();
+              });
+    tryUpsert(QStringLiteral("channels"), DeadlineQueue::Priority::Low,
+              std::chrono::milliseconds(50), [this]() {
+                  if (store_) store_->notifyChannelsCursorTick();
+              });
 }
 
 void VideoSyncController::attachDisplayPump() {
@@ -595,11 +600,21 @@ void VideoSyncController::attachDisplayPump() {
                          &VideoSyncController::onDisplayTick);
 }
 
-void VideoSyncController::onDisplayTick() {
-    if (telemetryVideoActive_ && primaryPlayer_ && primaryPlayer_->loaded() &&
-        !primaryPlayer_->paused() && !primaryPlayer_->seeking()) {
-        lastPrimaryMediaTime_ = primaryPlayer_->position();
-        enqueueTelemetry(false);
-    }
-    queue_.pump();
+void VideoSyncController::onDisplayTick() { queue_.pump(); }
+
+void VideoSyncController::updateSampleTimer() {
+    const bool shouldRun =
+        primaryPlayer_ && primaryPlayer_->loaded() && !primaryPlayer_->paused();
+    if (shouldRun == sampleTimer_.isActive()) return;
+    if (shouldRun)
+        sampleTimer_.start();
+    else
+        sampleTimer_.stop();
+}
+
+void VideoSyncController::onSampleTick() {
+    if (!primaryPlayer_ || !primaryPlayer_->loaded()) return;
+    lastPrimaryMediaTime_ = primaryPlayer_->position();
+    if (primaryPlayer_->seeking()) return;
+    enqueueTelemetry(false);
 }

--- a/src/app/VideoSyncController.h
+++ b/src/app/VideoSyncController.h
@@ -10,9 +10,9 @@
 // store signals itself, so QML no longer needs nested Connections blocks or
 // hand-rolled Timers for sync.
 //
-// libmpv time-pos only stores the last media time. Overlay, header, traces
-// and channels are enqueued on DeadlineQueue with deadlines and pumped from
-// QTimer / QQuickWindow::afterAnimating — never from processEvents.
+// libmpv time-pos is not observed. A 80 ms QTimer samples position() and
+// upserts overlay/header/HUD/traces onto DeadlineQueue. afterAnimating
+// pumps due jobs and never enqueues. Seek/pause use deadline-now.
 
 #pragma once
 
@@ -105,7 +105,6 @@ signals:
 
 private slots:
     void onPrimaryLoadedChanged();
-    void onPrimaryPositionChanged();
     void onPrimarySeekingChanged();
     void onPrimaryPausedChanged();
     void onReferenceLoadedChanged();
@@ -119,6 +118,8 @@ private slots:
     void onPausedAlignmentTick();
     void onLapAdvanceTick();
     void onDisplayTick();
+    void onSampleTick();
+    void updateSampleTimer();
 
 private:
     void connectPrimary();
@@ -173,8 +174,8 @@ private:
     QTimer pausedAlignmentTimer_;
     QTimer lapAdvanceTimer_;
 
+    QTimer sampleTimer_;
     QMetaObject::Connection primaryLoadedConn_;
-    QMetaObject::Connection primaryPositionConn_;
     QMetaObject::Connection primarySeekingConn_;
     QMetaObject::Connection primaryPausedConn_;
     QMetaObject::Connection primaryWindowConn_;

--- a/src/app/VideoTelemetryHud.cpp
+++ b/src/app/VideoTelemetryHud.cpp
@@ -66,6 +66,8 @@ void VideoTelemetryHud::setStore(TelemetryStore* store) {
         // compare-fraction map / brake peak, so it must not dirty the snapshot.
         connect(store_, &TelemetryStore::cursorFracChanged, this,
                 [this]() { update(); });
+        connect(store_, &TelemetryStore::hudCursorTick, this,
+                [this]() { update(); });
         connect(store_, &TelemetryStore::selectionChanged, this, [this]() {
             snapshotDirty_ = true;
             update();
@@ -96,7 +98,6 @@ void VideoTelemetryHud::setMediaTime(double mediaTime) {
     if (qFuzzyCompare(mediaTime_ + 1.0, mediaTime + 1.0)) return;
     mediaTime_ = mediaTime;
     emit mediaTimeChanged();
-    update();
 }
 
 QSGNode* VideoTelemetryHud::updatePaintNode(QSGNode* oldNode,

--- a/tests/DeadlineQueueTest.cpp
+++ b/tests/DeadlineQueueTest.cpp
@@ -87,6 +87,50 @@ private slots:
         QCOMPARE(value, 2);
         QVERIFY(queue.isEmpty());
     }
+
+    void containsReportsPendingKey() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        QVERIFY(!queue.contains(QStringLiteral("cursor")));
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(std::chrono::hours(1)), []() {});
+        QVERIFY(queue.contains(QStringLiteral("cursor")));
+        QVERIFY(!queue.contains(QStringLiteral("hud")));
+        QCOMPARE(queue.size(), 1);
+    }
+
+    void skipUpsertWhenKeyAlreadyPending() {
+        DeadlineQueue queue;
+        queue.setAutoPump(false);
+        int runs = 0;
+        int value = 0;
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(std::chrono::hours(1)), [&]() {
+                         ++runs;
+                         value = 1;
+                     });
+        if (!queue.contains(QStringLiteral("cursor")))
+            queue.upsert(QStringLiteral("cursor"),
+                         DeadlineQueue::Priority::High,
+                         QDeadlineTimer(std::chrono::hours(1)), [&]() {
+                             ++runs;
+                             value = 2;
+                         });
+        QCOMPARE(queue.size(), 1);
+        QVERIFY(queue.contains(QStringLiteral("cursor")));
+        QCOMPARE(queue.pump(), 0);
+        QCOMPARE(runs, 0);
+        QCOMPARE(value, 0);
+        queue.upsert(QStringLiteral("cursor"), DeadlineQueue::Priority::High,
+                     QDeadlineTimer(), [&]() {
+                         ++runs;
+                         value = 3;
+                     });
+        QCOMPARE(queue.pump(), 1);
+        QCOMPARE(runs, 1);
+        QCOMPARE(value, 3);
+        QVERIFY(!queue.contains(QStringLiteral("cursor")));
+    }
 };
 
 QTEST_GUILESS_MAIN(DeadlineQueueTest)

--- a/tests/LibraryModelTest.cpp
+++ b/tests/LibraryModelTest.cpp
@@ -217,6 +217,46 @@ private slots:
         QCOMPARE(filter.rowCount(), 0);
         QCOMPARE(reset.size(), 0);
     }
+
+    void cornerUpdateGeometryDoesNotReset() {
+        CornerListModel model;
+        QVector<CornerRow> rows(2);
+        rows[0].name = QStringLiteral("Turn 1");
+        rows[0].start = 0.10;
+        rows[0].end = 0.20;
+        rows[1].name = QStringLiteral("Turn 2");
+        rows[1].start = 0.40;
+        rows[1].end = 0.55;
+        model.refresh(rows);
+
+        QSignalSpy reset(&model, &QAbstractItemModel::modelReset);
+        QSignalSpy changed(&model, &QAbstractItemModel::dataChanged);
+        model.updateGeometry(0, 0.12, 0.22);
+        QCOMPARE(reset.size(), 0);
+        QCOMPARE(changed.size(), 1);
+        QCOMPARE(model.rowCount(), 2);
+        QCOMPARE(
+            model.data(model.index(0), CornerListModel::StartRole).toDouble(),
+            0.12);
+        QCOMPARE(
+            model.data(model.index(0), CornerListModel::EndRole).toDouble(),
+            0.22);
+        QCOMPARE(
+            model.data(model.index(1), CornerListModel::StartRole).toDouble(),
+            0.40);
+    }
+
+    void cornerUpdateGeometryNoOpWhenUnchanged() {
+        CornerListModel model;
+        QVector<CornerRow> rows(1);
+        rows[0].name = QStringLiteral("Turn 1");
+        rows[0].start = 0.1;
+        rows[0].end = 0.2;
+        model.refresh(rows);
+        QSignalSpy changed(&model, &QAbstractItemModel::dataChanged);
+        model.updateGeometry(0, 0.1, 0.2);
+        QCOMPARE(changed.size(), 0);
+    }
 };
 
 QTEST_GUILESS_MAIN(LibraryModelTest)


### PR DESCRIPTION
## Summary
- Corner drag was emitting `cornersChanged` on every mouse move, which rebuilt static traces, comparison alignment, the corners inspector, and `videoTimeChanged`. Live geometry now uses `cornerGeometryChanged` + overlay only; alignment/inspector commit on save (mouse up).
- Video playhead is polled on an 80 ms timer (`sampledMediaTime`). QML no longer binds `videoPlayer.position`. HUD/traces are separate deadline-queue keys.
- This is the no-video lag Tobi hit while editing corners. 1.7.1 did not touch that path.

## Test plan
- [ ] Edit corners with no video open: drag zone edges/move a turn. Cursor should follow without hitching the rest of the UI.
- [ ] Release mouse: inspector stats and YAML save still update.
- [ ] Add/delete/rename a corner still works.
- [ ] Playback still seeks/scrubs; overlay HUD still tracks (more slowly is fine).
- [ ] CI: `deadline-queue-test`, `library-model-test`.