### PR TITLE
1.8.5: keep Windows fullscreen video a composited window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -403,6 +403,15 @@ Native lap distance is accepted only when its continuity and total agree with in
   must not force fullscreen again. Finder document-open events use the same file
   path as CLI/dialog/drop opens, queued until the store is available.
 - Render through libmpv's OpenGL Render API in `MpvVideoItem`; never spawn the mpv CLI or embed a foreign native window.
+- Fullscreen is `Window.FullScreen` on the one application window, never a
+  second window. On Windows, `WindowsIntegration.cpp` sets the platform
+  window's `HasBorderInFullScreen` flag on first show: Qt's fullscreen is a
+  borderless popup matching the monitor exactly, which DWM and the GPU driver
+  treat as an exclusive OpenGL surface (display re-mode, refresh-rate switch,
+  black flicker, other top-levels unable to appear on top). The 1-px
+  `WS_BORDER` inset keeps it a composited window; Qt still reports
+  `FullScreen`. Do not replace this with a frameless screen-sized window —
+  that is the same exclusive-surface shape.
 - Embedded playback explicitly uses builtin bilinear scale/cscale/dscale. This
   avoids proven uninitialized padded scaler LUTs in mpv0.41 that can propagate
   NaNs into black video. It is a display-filter tradeoff, not altered image-model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable user-facing changes are documented here.
 - Validate each registered model's exact size, hash and contract on a worker;
   large-file hashes use bounded streaming buffers. CI and package audits verify
   all bundled models/notices and exercise cold offline loading on every platform.
+- Keep Windows fullscreen video a composited window instead of a game-style
+  exclusive surface: no display re-mode or refresh-rate switch, no black
+  flicker entering and leaving fullscreen, and Preferences/Channels/dialogs can
+  appear above the video.
 
 ## 1.8.2 — 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable user-facing changes are documented here.
 
+## 1.8.5 — 2026-09-08
+
+- Keep Windows fullscreen video a composited window instead of a game-style
+  exclusive surface: no display re-mode or refresh-rate switch, no black
+  flicker entering and leaving fullscreen, and Preferences/Channels/dialogs can
+  appear above the video.
+
 ## 1.8.4 — 2026-09-08
 
 - Gauge discovery is opt-in per video: nothing is decoded or detected until
@@ -36,10 +43,6 @@ All notable user-facing changes are documented here.
 - Validate each registered model's exact size, hash and contract on a worker;
   large-file hashes use bounded streaming buffers. CI and package audits verify
   all bundled models/notices and exercise cold offline loading on every platform.
-- Keep Windows fullscreen video a composited window instead of a game-style
-  exclusive surface: no display re-mode or refresh-rate switch, no black
-  flicker entering and leaving fullscreen, and Preferences/Channels/dialogs can
-  appear above the video.
 
 ## 1.8.2 — 2026-09-06
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ endif()
 find_package(Qt6 6.5 REQUIRED COMPONENTS
   Concurrent Core Gui Quick QuickControls2 Qml Network)
 if(WIN32)
+  # Private headers for the QWindowsWindow native interface used by
+  # src/app/WindowsIntegration.cpp; Qt exports Qt6::GuiPrivate only on request.
+  find_package(Qt6 6.5 REQUIRED COMPONENTS GuiPrivate)
   get_filename_component(OMATRACK_TOOLCHAIN_BIN_DIR
     "${CMAKE_CXX_COMPILER}" DIRECTORY)
   get_filename_component(OMATRACK_TOOLCHAIN_PREFIX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(omatrack VERSION 1.8.4 LANGUAGES CXX)
+project(omatrack VERSION 1.8.5 LANGUAGES CXX)
 if(WIN32)
   # Windows release layout: the app ships as a flat zip, so executables and
   # their load-time DLLs install at the prefix root and every non-binary

--- a/packaging/linux/io.github.tobi.omatrack.metainfo.xml
+++ b/packaging/linux/io.github.tobi.omatrack.metainfo.xml
@@ -24,6 +24,13 @@
   <url type="bugtracker">https://github.com/tobi/omatrack/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.8.5" date="2026-09-08">
+      <description>
+        <p>Windows fullscreen video stays a composited window: no display
+        re-mode or refresh-rate switch, no black flicker, and dialogs can
+        appear above the video.</p>
+      </description>
+    </release>
     <release version="1.8.4" date="2026-09-08">
       <description>
         <p>Gauge discovery is opt-in per video and builds confidence by vote:

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -216,7 +216,9 @@ target_link_libraries(omatrack PRIVATE
   Qt6::Qml
   Qt6::Network)
 if(WIN32)
-  target_link_libraries(omatrack PRIVATE dwmapi shell32)
+  # Qt6::GuiPrivate exposes <QtGui/qpa/qplatformwindow_p.h>, the native
+  # interface WindowsIntegration.cpp uses to keep fullscreen composited.
+  target_link_libraries(omatrack PRIVATE Qt6::GuiPrivate dwmapi shell32)
 endif()
 
 # After link libraries so the PCH sees the same include dirs as the TUs.

--- a/src/app/WindowsIntegration.cpp
+++ b/src/app/WindowsIntegration.cpp
@@ -4,6 +4,7 @@
 #include <QGuiApplication>
 #include <QPalette>
 #include <QWindow>
+#include <QtGui/qpa/qplatformwindow_p.h>
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -69,26 +70,54 @@ void useDarkTitleBar(QWindow* window) {
                           sizeof(enabled));
 }
 
+// Qt implements Window.FullScreen on Windows as a borderless WS_POPUP window
+// sized exactly to the monitor. Because the scene graph runs on OpenGL (the
+// libmpv render API needs it), DWM and the display driver treat that surface
+// like a game's exclusive fullscreen: the display re-modes, the screen goes
+// black for a moment, variable-refresh monitors switch rate, and — Qt's
+// documented DWM limitation — other top-level windows (Preferences,
+// Channels, dialogs) cannot appear above it. Qt's remedy is the platform
+// window's HasBorderInFullScreen flag: the popup keeps WS_BORDER, the
+// client area is inset by one pixel, and the window never matches the
+// screen exactly, so it stays a composited window. Qt still reports it as
+// FullScreen (isFullScreen_sys() accounts for the border), so the QML
+// visibility round-trip is unchanged. The flag lives on the platform
+// window, so it is set once the native handle exists — the first Show.
+void keepFullScreenComposited(QWindow* window) {
+    if (!window || !window->isTopLevel()) return;
+    using QNativeInterface::Private::QWindowsWindow;
+    if (auto* native = window->nativeInterface<QWindowsWindow>())
+        native->setHasBorderInFullScreen(true);
+}
+
 class WindowsWindowAppearance final : public QObject {
 public:
-    explicit WindowsWindowAppearance(QObject* parent) : QObject(parent) {}
+    explicit WindowsWindowAppearance(QObject* parent, bool darkTitleBar)
+        : QObject(parent), darkTitleBar_(darkTitleBar) {}
 
 protected:
     bool eventFilter(QObject* watched, QEvent* event) override {
-        if (event->type() == QEvent::Show)
-            useDarkTitleBar(qobject_cast<QWindow*>(watched));
+        if (event->type() == QEvent::Show) {
+            auto* window = qobject_cast<QWindow*>(watched);
+            keepFullScreenComposited(window);
+            if (darkTitleBar_) useDarkTitleBar(window);
+        }
         return QObject::eventFilter(watched, event);
     }
+
+private:
+    const bool darkTitleBar_;
 };
 
 }  // namespace
 
 void initializeWindowsIntegration(QGuiApplication& app) {
     SetCurrentProcessExplicitAppUserModelID(L"io.github.tobi.omatrack");
-    if (highContrastEnabled()) return;
-
-    QGuiApplication::setPalette(omatrackDarkPalette());
-    app.installEventFilter(new WindowsWindowAppearance(&app));
+    // High contrast keeps the system palette and title bars; the fullscreen
+    // compositing fix applies regardless.
+    const bool themed = !highContrastEnabled();
+    if (themed) QGuiApplication::setPalette(omatrackDarkPalette());
+    app.installEventFilter(new WindowsWindowAppearance(&app, themed));
 }
 
 }  // namespace omatrack


### PR DESCRIPTION
Qt implements Window.FullScreen on Windows as a borderless WS_POPUP sized
exactly to the monitor. With the OpenGL scene graph libmpv requires, DWM and
the display driver treat that as a game's exclusive fullscreen surface: the
display re-modes, the screen blanks, VRR monitors switch refresh rate, and
other top-level windows cannot appear above it.

Set the platform window's HasBorderInFullScreen flag through the Qt 6
native interface on first show. The popup keeps WS_BORDER and a 1-px inset,
so it stays a composited window while Qt still reports FullScreen. Applies
under high contrast too; only the dark palette/title bar stay conditional.

Verification: Windows CI (MSYS2 UCRT64) compiles `WindowsIntegration.cpp` against `Qt6::GuiPrivate`; Linux/macOS unaffected. Manual check on a Windows box: enter fullscreen video — no display blank / refresh switch, and Preferences opens above the video.

Made with [Cursor](https://cursor.com)