### PR TITLE
1.8.4: gauge discovery opt-in per video, vote-based evidence, no overlaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,11 +466,24 @@ Native lap distance is accepted only when its continuity and total agree with in
 - Opening a video without embedded telemetry clears active/reference laps and
   gives the video the full analysis workspace. Telemetry-bearing videos retain
   the synchronized trace workspace below playback when leaving fullscreen.
-- `ImageTelemetryController` uses **Discover → Confirm → Extract**. Enabling
-  `video.image_telemetry` starts pixel-only discovery, not reading. Full-source
+- `ImageTelemetryController` uses **Discover → Confirm → Extract**.
+  `video.image_telemetry` only allows the feature; discovery itself is the
+  runtime `discovering` opt-in the overlay toggle sets for the current video,
+  and every source change or settings reset clears it. Nothing decodes or
+  detects until the user asks. Discovery is pixel-only, not reading. Full-source
   boxes stay on the video while a serial worker samples approximately every three
-  seconds. Confidence is repeated spatial/type evidence at independent actual PTS,
-  never repeated paused frames or calibrated probabilities. The user may edit,
+  seconds. Confidence is a ballot: each independent actual-PTS frame votes for
+  the tracks it re-detects and against those it does not; an automatic learned
+  track is shown only after `GaugeSetup::VotesToShow` votes, and can be
+  confirmed without visual confirmation only after `VotesToConfirm`. Repeated
+  paused frames are not votes and nothing is a calibrated probability.
+  `GaugeEvidence::resolveOverlaps` keeps boxes disjoint: profile anchors and
+  user-owned tracks (edited, confirmed, persisted proposals) always keep their
+  place; automatic tracks are admitted heaviest first with weight votes × √area,
+  so a consistently seen large gauge suppresses the small glyph boxes nested in
+  it. Suppressed tracks keep voting and return if they outweigh the winner;
+  candidates below the vote threshold cannot suppress anything. Confirmation
+  prunes hidden and suppressed automatic tracks before saving. The user may edit,
   relabel, choose fill direction, disable and visually confirm boxes. Confirm saves
   the setup; only the separate **Start extraction** action admits compatible selected
   crops into the progressive 5 Hz recording. Discovery can inspect native-bearing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 All notable user-facing changes are documented here.
 
-## 1.8.3 — 2026-09-07
+## 1.8.4 — 2026-09-08
 
-- Discover gauges while video plays, review/edit the source-frame boxes, confirm
-  the setup, then explicitly start extraction. Remembered extension proposals
-  default on but always require fresh image validation; native telemetry wins.
 - Gauge discovery is opt-in per video: nothing is decoded or detected until
   **Discover gauges** is chosen on that video, and opening another video turns
   it off again. The image-telemetry preference only allows the feature.
@@ -14,6 +11,12 @@ All notable user-facing changes are documented here.
   frames agree and fades when frames stop seeing it, overlapping boxes are
   resolved so a consistently seen larger gauge wins over the small glyph boxes
   inside it, and user-edited or confirmed boxes are never hidden by detections.
+
+## 1.8.3 — 2026-09-07
+
+- Discover gauges while video plays, review/edit the source-frame boxes, confirm
+  the setup, then explicitly start extraction. Remembered extension proposals
+  default on but always require fresh image validation; native telemetry wins.
 - Include the proven reader, tiny general detector and larger AiM detector
   offline, with verified companion contracts and upstream notices. No model
   download or account is needed to use the shipped bundle; footage stays local.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable user-facing changes are documented here.
 - Discover gauges while video plays, review/edit the source-frame boxes, confirm
   the setup, then explicitly start extraction. Remembered extension proposals
   default on but always require fresh image validation; native telemetry wins.
+- Gauge discovery is opt-in per video: nothing is decoded or detected until
+  **Discover gauges** is chosen on that video, and opening another video turns
+  it off again. The image-telemetry preference only allows the feature.
+- Detected gauges earn their place by vote: a box appears after two independent
+  frames agree and fades when frames stop seeing it, overlapping boxes are
+  resolved so a consistently seen larger gauge wins over the small glyph boxes
+  inside it, and user-edited or confirmed boxes are never hidden by detections.
 - Include the proven reader, tiny general detector and larger AiM detector
   offline, with verified companion contracts and upstream notices. No model
   download or account is needed to use the shipped bundle; footage stays local.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(omatrack VERSION 1.8.3 LANGUAGES CXX)
+project(omatrack VERSION 1.8.4 LANGUAGES CXX)
 if(WIN32)
   # Windows release layout: the app ships as a flat zip, so executables and
   # their load-time DLLs install at the prefix root and every non-binary

--- a/docs/GAUGE_DISCOVERY.md
+++ b/docs/GAUGE_DISCOVERY.md
@@ -2,13 +2,44 @@
 
 ## Native workflow
 
+The `video.image_telemetry` preference only allows image telemetry. Discovery is
+a per-video opt-in: the overlay's **Discover gauges** toggle sets the
+controller's runtime `discovering` flag, which every source change, reopen or
+settings reset clears. Until then nothing is decoded and no detector runs; a
+saved per-file or extension proposal is not even loaded. Choosing the toggle
+while the preference is off turns the preference on as well — that is the
+explicit opt-in.
+
 Enabling **Discover gauges** starts discovery, not reading or cache scanning.
 Playback continues. A serial `AsyncJob` decodes a full source frame approximately
 every three seconds; observations retain the decoder's actual presentation PTS.
 Temporal evidence requires at least two seconds separation from **every** earlier
 sample, including frames revisited after seeking. Repeated paused frames do not
-increase evidence. Repeated spatial/type matches increase the displayed seen
-count; misses/conflicts lower it. This is not a calibrated probability.
+increase evidence. This is not a calibrated probability.
+
+Each independent frame is one ballot (`GaugeEvidence::observe`). A detection
+that overlaps an existing track by IoU > 0.5 with the same backend,
+representation and semantic votes for it (+1, capped at 20); a track no
+detection voted for loses a vote (−1, floor 0) and counts a consecutive miss.
+Unmatched detections enter as hidden candidates with one vote. An automatic
+learned track becomes visible on the video and in the setup panel only at
+`GaugeSetup::VotesToShow` (2) votes, so a glyph seen on a single frame never
+appears; it retires after three consecutive misses, and a validated track loses
+its confirmation after two. Profile anchors are shown from their first frame
+because they come from the reviewed structural check, not learned detection.
+
+After the ballot, `resolveOverlaps` keeps the inventory disjoint. Two boxes
+conflict when their intersection covers at least half of the smaller one
+(nesting and near-duplicates, not touching neighbours). Anchored tracks —
+profile anchors, user edits, visual confirmations and persisted proposals —
+always keep their place. Automatic tracks are admitted heaviest first, weight
+being votes × √area: a box four times the area counts double, so two votes for
+a needle dial outweigh four votes for each digit glyph nested inside it, while
+a single frame's screen-sized box cannot hide an established gauge because
+candidates below the vote threshold never suppress anything. A suppressed
+track is hidden, not deleted: it keeps voting and returns if the winner fades.
+**Confirm setup** prunes hidden and suppressed automatic tracks before saving,
+so a saved setup carries evidence rather than per-frame noise.
 
 The source-normalized boxes cover the whole displayed video, not a HUD subregion.
 Display letterboxing is removed before projecting boxes, using the actual player
@@ -204,7 +235,14 @@ optional opt-in; all three shipped models work without first-run network access.
 - `gauge-setup-test`: independent PTS, seek revisits, geometry mismatch, proposal
   revalidation, stable identity, stale-track retirement, selected masks and unknowns;
   separate profile/inventory matching, edit/disable preservation, reserved profile
-  capacity, boundary serialization and reading identity under unselected churn.
+  capacity, boundary serialization and reading identity under unselected churn;
+  two-vote visibility with decay, nested glyphs losing to a larger gauge and
+  returning when it fades, touching neighbours coexisting, a one-frame
+  screen-sized box unable to hide an established gauge, user-owned tracks never
+  outvoted, and confirmation pruning.
+- Both GL harnesses (`GaugeDiscoveryAutotest`, `ImageTelemetryScanAutotest`)
+  first require that the enabled preference alone ran no discovery, then opt in
+  per opened source the way the overlay toggle does.
 - `gauge-reader-parity-test` (private fixtures): original numerical parity plus
   relocated configured crops, four directions, exact bytes and disabled fields.
 - `gauge-detector-test`: synthetic resize/decode/loader/finite guards; optional private

--- a/packaging/linux/io.github.tobi.omatrack.metainfo.xml
+++ b/packaging/linux/io.github.tobi.omatrack.metainfo.xml
@@ -24,6 +24,20 @@
   <url type="bugtracker">https://github.com/tobi/omatrack/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="1.8.4" date="2026-09-08">
+      <description>
+        <p>Gauge discovery is opt-in per video and builds confidence by vote:
+        boxes appear only after independent frames agree, larger gauges win
+        over the glyph boxes nested in them, and boxes never overlap.</p>
+      </description>
+    </release>
+    <release version="1.8.3" date="2026-09-07">
+      <description>
+        <p>Discover, confirm and extract gauges from video with the offline
+        model bundle: proven reader, tiny general detector and the larger AiM
+        detector, all verified and shipped without downloads.</p>
+      </description>
+    </release>
     <release version="1.8.2" date="2026-09-06">
       <description>
         <p>Progressive image-derived telemetry for supported video overlays,

--- a/src/app/GaugeDiscoveryAutotest.cpp
+++ b/src/app/GaugeDiscoveryAutotest.cpp
@@ -138,6 +138,22 @@ private:
             if (!require(player_ && controller_, "missing player/controller"))
                 return;
         }
+        // Discovery is a per-video opt-in; every source change (blank swap,
+        // restart) clears it. Phase 1 first proves the enabled preference
+        // alone runs nothing, then opts in the way the user does through the
+        // overlay toggle; later source changes re-arm the same way.
+        if (phase_ >= 1 && controller_->enabled() &&
+            !controller_->discovering()) {
+            if (!require(controller_->discoverySamples() == 0 &&
+                             controller_->inferenceRuns() == 0,
+                         "discovery ran without the per-video opt-in"))
+                return;
+            if (phase_ == 1 && phaseClock_.elapsed() < 1000) return;
+            controller_->setDiscovering(true);
+            if (!require(controller_->discovering(), "opt-in was refused"))
+                return;
+            if (phase_ == 1) phaseClock_.restart();
+        }
         if (controller_->discoverySamples() > reportedSamples_) {
             reportedSamples_ = controller_->discoverySamples();
             qInfo() << "GAUGE DISCOVERY backend"

--- a/src/app/GaugeDiscoveryOverlay.qml
+++ b/src/app/GaugeDiscoveryOverlay.qml
@@ -60,7 +60,7 @@ Item {
         target: root.controller
     }
     Repeater {
-        model: root.controller.enabled && root.controller.geometryCompatible ? root.controller.gauges : null
+        model: (root.controller.discovering || root.controller.phase !== ImageTelemetryController.Discovery) && root.controller.geometryCompatible ? root.controller.gauges : null
 
         delegate: Rectangle {
             id: boxItem
@@ -157,18 +157,27 @@ Item {
         spacing: 4
 
         CheckBox {
+            id: discoverToggle
+
             Material.foreground: Style.foregroundColor
-            checked: root.controller.enabled
+            checked: root.controller.discovering
             font.pixelSize: Style.smallFontSize
+            objectName: "gaugeDiscoverToggle"
             text: "Discover gauges"
 
-            onToggled: Store.imageTelemetryEnabled = checked
+            // Opt in for this video only. Opening another video turns it off
+            // again; the preference merely allows image telemetry at all.
+            onToggled: {
+                if (discoverToggle.checked && !Store.imageTelemetryEnabled)
+                    Store.imageTelemetryEnabled = true;
+                root.controller.discovering = discoverToggle.checked;
+            }
         }
         ToolButton {
             Material.foreground: Style.foregroundColor
             font.pixelSize: Style.smallFontSize
             text: root.reviewOpen ? "Hide setup" : "Review setup"
-            visible: root.controller.enabled
+            visible: root.controller.discovering || root.controller.phase !== ImageTelemetryController.Discovery
 
             onClicked: root.reviewOpen = !root.reviewOpen
         }
@@ -184,7 +193,9 @@ Item {
         color: Style.videoControlBackgroundColor
         height: Math.max(0, Math.min(root.height - 136, contents.implicitHeight + 16))
         radius: 4
-        visible: root.controller.enabled && root.reviewOpen
+        // A confirmed or extracting setup stays reviewable even after the
+        // discovery toggle is turned off again.
+        visible: (root.controller.discovering || root.controller.phase !== ImageTelemetryController.Discovery) && root.reviewOpen
         width: Math.min(360, root.width - 16)
 
         MouseArea {

--- a/src/app/GaugeSetup.cpp
+++ b/src/app/GaugeSetup.cpp
@@ -16,13 +16,48 @@ bool validBox(const QRectF& b) {
            // readerField's exact reviewed-crop admission remains unchanged.
            b.right() <= 1 + 1e-9 && b.bottom() <= 1 + 1e-9;
 }
-double overlap(const QRectF& a, const QRectF& b) {
+double area(const QRectF& r) { return r.width() * r.height(); }
+double intersection(const QRectF& a, const QRectF& b) {
     const auto r = a.intersected(b);
-    const double i = r.isEmpty() ? 0 : r.width() * r.height();
-    const double u = a.width() * a.height() + b.width() * b.height() - i;
+    return r.isEmpty() ? 0 : area(r);
+}
+double overlap(const QRectF& a, const QRectF& b) {
+    const double i = intersection(a, b);
+    const double u = area(a) + area(b) - i;
     return u > 0 ? i / u : 0;
 }
+// Named product decisions for the per-frame ballot (see GaugeEvidence).
+// A detection re-identifies a track above this IoU.
+constexpr double kMatchIou = 0.5;
+// Two tracks conflict when their intersection covers this fraction of the
+// smaller box: nesting and near-duplicates, not touching neighbours.
+constexpr double kConflictFraction = 0.5;
+// Weight = votes × area^kAreaExponent. 0.5 makes a box four times the area
+// worth twice the votes, so consistent large gauges beat many small glyphs
+// without a one-vote screen-sized box beating an established small gauge.
+constexpr double kAreaExponent = 0.5;
+constexpr int kMaxVotes = 20;
+// Consecutive independent frames without a vote before an automatic track
+// is dropped and before a validated track loses its confirmation.
+constexpr int kMissesToRetire = 3;
+constexpr int kMissesToUnconfirm = 2;
+
+bool conflicts(const QRectF& a, const QRectF& b) {
+    const double smaller = std::min(area(a), area(b));
+    return smaller > 0 && intersection(a, b) / smaller >= kConflictFraction;
+}
+double weight(const GaugeRegion& r) {
+    return r.hits * std::pow(area(r.box), kAreaExponent);
+}
 }  // namespace
+bool GaugeRegion::visible() const {
+    return !suppressed && (anchored() || hits >= GaugeSetup::VotesToShow);
+}
+void GaugeSetup::pruneInvisible() {
+    regions.erase(std::remove_if(regions.begin(), regions.end(),
+                                 [](const auto& r) { return !r.visible(); }),
+                  regions.end());
+}
 bool GaugeSetup::valid() const {
     if (sourceSize.width() <= 0 || sourceSize.height() <= 0 ||
         sourceSize.width() > 16384 || sourceSize.height() > 16384 ||
@@ -268,10 +303,12 @@ bool GaugeEvidence::observe(qint64 pts, QSize size,
         }
     }
     setup.sourceSize = size;
+    // Ballot: every existing track either collects this frame's vote or
+    // loses one.
     QSet<int> used;
     for (auto& r : setup.regions) {
         int best = -1;
-        double bestOverlap = .5;
+        double bestOverlap = kMatchIou;
         for (int i = 0; i < observations.size(); ++i) {
             const auto& o = observations[i];
             if (used.contains(i) || !validBox(o.box) ||
@@ -300,7 +337,7 @@ bool GaugeEvidence::observe(qint64 pts, QSize size,
                 (r.profileKey.isEmpty() ||
                  (o.direction == r.direction &&
                   GaugeSetup::readerField(r, size) >= 0))) {
-                r.hits = std::min(20, r.hits + 1);
+                r.hits = std::min(kMaxVotes, r.hits + 1);
                 r.misses = 0;
                 r.score = o.score;
                 continue;
@@ -308,15 +345,16 @@ bool GaugeEvidence::observe(qint64 pts, QSize size,
         }
         r.hits = std::max(0, r.hits - 1);
         ++r.misses;
-        if (r.misses >= 2) r.confirmed = false;
+        if (r.misses >= kMissesToUnconfirm) r.confirmed = false;
     }
     setup.regions.erase(
         std::remove_if(setup.regions.begin(), setup.regions.end(),
                        [](const auto& r) {
-                           return r.misses >= 3 && !r.edited && !r.confirmed &&
-                                  !r.proposal;
+                           return r.misses >= kMissesToRetire && !r.userOwned();
                        }),
         setup.regions.end());
+    // Unmatched detections become hidden candidates with one vote; they show
+    // once a second independent frame agrees.
     for (int i = 0; i < observations.size(); ++i) {
         if (used.contains(i) || !validBox(observations[i].box)) continue;
         auto r = observations[i];
@@ -335,8 +373,45 @@ bool GaugeEvidence::observe(qint64 pts, QSize size,
             [&r](const auto& existing) { return existing.id == r.id; }));
         r.confirmed = false;
         r.hits = 1;
+        r.misses = 0;
         setup.regions.append(r);
     }
+    resolveOverlaps();
     return true;
+}
+void GaugeEvidence::resolveOverlaps() {
+    // Anchored tracks keep their place unconditionally (a user may deliberately
+    // overlap two edits). Automatic tracks are admitted heaviest first and
+    // suppressed when they conflict with anything already admitted. A
+    // candidate below the vote threshold is hidden anyway and cannot
+    // suppress anything: one frame's screen-sized box never hides an
+    // established gauge. Order is deterministic: weight, then area, then id.
+    QVector<int> automatic, kept;
+    for (int i = 0; i < setup.regions.size(); ++i) {
+        auto& r = setup.regions[i];
+        r.suppressed = false;
+        if (r.anchored())
+            kept.append(i);
+        else
+            automatic.append(i);
+    }
+    std::sort(automatic.begin(), automatic.end(), [this](int a, int b) {
+        const auto& ra = setup.regions[a];
+        const auto& rb = setup.regions[b];
+        const double wa = weight(ra), wb = weight(rb);
+        if (wa != wb) return wa > wb;
+        const double aa = area(ra.box), ab = area(rb.box);
+        if (aa != ab) return aa > ab;
+        return ra.id < rb.id;
+    });
+    for (const int i : automatic) {
+        auto& r = setup.regions[i];
+        for (const int k : kept)
+            if (conflicts(r.box, setup.regions[k].box)) {
+                r.suppressed = true;
+                break;
+            }
+        if (!r.suppressed && r.hits >= GaugeSetup::VotesToShow) kept.append(i);
+    }
 }
 }  // namespace omatrack

--- a/src/app/GaugeSetup.h
+++ b/src/app/GaugeSetup.h
@@ -27,16 +27,39 @@ struct GaugeRegion {
     bool enabled = true, confirmed = false, edited = false;
     bool proposal =
         false;  // runtime protection for persisted/user-confirmed setup
+    // Runtime only: lost an overlap contest to a heavier track this frame.
+    // Keeps voting; shown again if it outweighs the winner later.
+    bool suppressed = false;
+    // hits is the vote count: +1 per independent frame that re-detects the
+    // track, -1 per independent frame that does not. misses counts
+    // consecutive frames without a match.
     int hits = 0, misses = 0;
     double score = 0;
+    // A user edit, a visual confirmation or a persisted proposal: misses mark
+    // it stale but never retire it.
+    bool userOwned() const { return edited || confirmed || proposal; }
+    // User-owned, or one of the reviewed structural profile anchors: shown
+    // from its first frame and never outvoted or hidden by an automatic track.
+    bool anchored() const { return userOwned() || !profileKey.isEmpty(); }
+    // What the setup panel lists and the video overlays. An automatic learned
+    // track must be seen on two independent frames before it appears at all,
+    // and must not currently be suppressed by an overlapping heavier track.
+    bool visible() const;
 };
 struct GaugeSetup {
     static constexpr int MaxInventoryRegions = 32;
     static constexpr int MaxProfileRegions = 4;
+    // Independent-frame votes before an automatic learned track is shown, and
+    // before an enabled track can be confirmed without visual confirmation.
+    static constexpr int VotesToShow = 2;
+    static constexpr int VotesToConfirm = 3;
     QSize sourceSize;
     QString detectorIdentity;
     QVector<GaugeRegion> regions;
     bool valid() const;
+    // Drops automatic tracks that are not visible (below the vote threshold
+    // or suppressed) so a saved setup carries evidence, not per-frame noise.
+    void pruneInvisible();
     QVariantMap toMap() const;
     static GaugeSetup fromMap(const QVariantMap& map);
     QString fingerprint() const;
@@ -55,6 +78,19 @@ struct GaugeSetup {
 // GUI-owned temporal state, fed only worker observations with actual decoded
 // PTS. A seek cancels a job but does not make a previously seen frame
 // independent.
+//
+// Every independent frame is one ballot. A detection that overlaps an
+// existing track by IoU > 0.5 (same backend, same representation and
+// semantic) votes for it; a track no frame voted for loses a vote. New
+// detections enter as hidden candidates with one vote. After the ballot,
+// overlapping tracks are resolved: anchored tracks (profile anchors, user
+// edits, confirmations, persisted proposals) always keep their place; among
+// automatic tracks the heavier one wins, where weight is votes × √area, so a
+// gauge four times the area counts double and one consistently seen large
+// box beats a cloud of small glyph boxes inside it. Losers are suppressed,
+// not deleted: they keep voting and reappear if they outweigh the winner.
+// Two boxes conflict when the intersection covers at least half of the
+// smaller one, so slightly touching neighbours coexist but nesting does not.
 class GaugeEvidence {
 public:
     GaugeSetup setup;
@@ -66,6 +102,7 @@ public:
     bool reviewedLayoutVerified() const { return reviewedLayoutVerified_; }
 
 private:
+    void resolveOverlaps();
     bool reviewedLayoutVerified_ = false;
     QSet<qint64> seen_;
     int nextId_ = 1;

--- a/src/app/ImageTelemetryController.cpp
+++ b/src/app/ImageTelemetryController.cpp
@@ -146,6 +146,33 @@ void ImageTelemetryController::setEnabled(bool enabled) {
     emit enabledChanged();
     emit scanStateChanged();
 }
+void ImageTelemetryController::setDiscovering(bool discovering) {
+    if (discovering && !enabled_) return;
+    if (discovering_ == discovering) return;
+    discovering_ = discovering;
+    if (discovering) {
+        // Fresh cadence so the first frame is sampled now, not up to three
+        // seconds from now. Evidence collected before a pause is kept.
+        lastDiscoveryTarget_ = -10;
+        nextDiscoveryMs_ = 0;
+        if (phase_ == Discovery && eligible_)
+            setStatus(QStringLiteral(
+                "Discover gauges · play video to gather independent frames"));
+        emit discoveringChanged();
+        sample();
+        return;
+    }
+    discoveryJob_.reset();
+    emit discoveringChanged();
+    if (phase_ == Discovery) setStatus(idleStatus());
+}
+QString ImageTelemetryController::idleStatus() const {
+    if (!enabled_) return QStringLiteral("Image telemetry off");
+    if (!eligible_)
+        return QStringLiteral("Native telemetry / no standalone video");
+    return QStringLiteral(
+        "Gauge discovery off · Discover gauges to scan this video");
+}
 void ImageTelemetryController::setEligible(bool eligible) {
     if (eligible_ == eligible) return;
     eligible_ = eligible;
@@ -230,13 +257,14 @@ void ImageTelemetryController::reset() {
     geometryCompatible_ = false;
     lastDiscoveryTarget_ = -10;
     nextDiscoveryMs_ = 0;
+    // Discovery is a per-video decision: a new source, a reopen or a settings
+    // change never carries the opt-in over.
+    if (discovering_) {
+        discovering_ = false;
+        emit discoveringChanged();
+    }
     refreshGauges();
-    setStatus(
-        !enabled_ ? QStringLiteral("Image telemetry off")
-        : eligible_
-            ? QStringLiteral(
-                  "Discover gauges · play video to gather independent frames")
-            : QStringLiteral("Native telemetry / no standalone video"));
+    setStatus(idleStatus());
 }
 void ImageTelemetryController::resetForSeek() {
     // A seek invalidates current readings, NOT already collected source data.
@@ -261,9 +289,10 @@ bool ImageTelemetryController::canConfirm() const {
         return false;
     bool selected = false;
     for (const auto& r : evidence_.setup.regions) {
-        if (!r.enabled) continue;
+        if (!r.enabled || !r.visible()) continue;
         selected = true;
-        if (r.hits < 3 && !r.confirmed) return false;
+        if (r.hits < omatrack::GaugeSetup::VotesToConfirm && !r.confirmed)
+            return false;
     }
     return selected;
 }
@@ -299,6 +328,9 @@ void ImageTelemetryController::refreshGeometry() {
 void ImageTelemetryController::refreshGauges() {
     QVector<GaugeRegionRow> rows;
     for (const auto& r : evidence_.setup.regions) {
+        // Hidden candidates keep voting in the evidence but never reach the
+        // panel or the video until they have earned their place.
+        if (!r.visible()) continue;
         GaugeRegionRow row;
         row.key = r.id;
         row.origin = !r.profileKey.isEmpty() ? QStringLiteral("AiM profile")
@@ -349,6 +381,9 @@ void ImageTelemetryController::confirmGauge(const QString& key) {
 void ImageTelemetryController::confirmSetup(bool extensionDefault) {
     if (!canConfirm()) return;
     discoveryJob_.reset();
+    // Only tracks that earned visibility are confirmed and saved; one-frame
+    // candidates and suppressed losers are noise, not setup.
+    evidence_.setup.pruneInvisible();
     for (auto& r : evidence_.setup.regions) {
         r.confirmed = r.enabled;
         r.proposal = true;
@@ -578,7 +613,7 @@ void ImageTelemetryController::sample() {
         awaitingSeek_)
         return;
     if (phase_ != Extracting) {
-        if (phase_ == Discovery) discover(player_->position());
+        if (phase_ == Discovery && discovering_) discover(player_->position());
         return;
     }
     if (!eligible_ || !geometryCompatible_)

--- a/src/app/ImageTelemetryController.h
+++ b/src/app/ImageTelemetryController.h
@@ -48,6 +48,10 @@ class ImageTelemetryController : public QObject {
                    playerChanged FINAL)
     Q_PROPERTY(
         bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged FINAL)
+    // Per-video opt-in. Nothing is decoded or detected until the user asks;
+    // a new source, a reopen or a settings change turns it off again.
+    Q_PROPERTY(bool discovering READ discovering WRITE setDiscovering NOTIFY
+                   discoveringChanged FINAL)
     Q_PROPERTY(bool eligible READ eligible WRITE setEligible NOTIFY
                    eligibleChanged FINAL)
     Q_PROPERTY(QString modelPath READ modelPath WRITE setModelPath NOTIFY
@@ -119,6 +123,8 @@ public:
     void setPlayer(MpvVideoItem* player);
     bool enabled() const { return enabled_; }
     void setEnabled(bool enabled);
+    bool discovering() const { return discovering_; }
+    void setDiscovering(bool discovering);
     bool eligible() const { return eligible_; }
     void setEligible(bool eligible);
     const QString& modelPath() const { return modelPath_; }
@@ -158,6 +164,7 @@ signals:
     void setupChanged();
     void playerChanged();
     void enabledChanged();
+    void discoveringChanged();
     void eligibleChanged();
     void modelPathChanged();
     void detectorPathChanged();
@@ -176,6 +183,7 @@ private:
     void retireWorker();
     void sample();
     void setStatus(const QString& message);
+    QString idleStatus() const;
     void invalidate();
     void refreshCurrent();
     void apply(const std::shared_ptr<ImageTelemetryResult>& result);
@@ -198,7 +206,8 @@ private:
     QElapsedTimer clock_;
     QString modelPath_, detectorPath_, status_, cachePath_, discoveryBackend_;
     double discoveryMs_ = 0, discoveryLoadMs_ = 0;
-    bool enabled_ = true, eligible_ = false, scanAhead_ = false;
+    bool enabled_ = true, discovering_ = false, eligible_ = false,
+         scanAhead_ = false;
     bool valid_ = false, blocked_ = false, awaitingSeek_ = false;
     bool complete_ = false, cacheComplete_ = false, pendingSave_ = false,
          pendingWatch_ = false;

--- a/src/app/ImageTelemetryScanAutotest.cpp
+++ b/src/app/ImageTelemetryScanAutotest.cpp
@@ -484,6 +484,16 @@ private:
             timeline();
         }
         if (finished_) return;
+        // Discovery is a per-video opt-in that every source change clears;
+        // the enabled preference alone must not run it. Opt in here the way
+        // the user does through the overlay toggle for each opened source.
+        if (reader_->enabled() && !reader_->discovering() &&
+            player_->loaded()) {
+            if (!require(reader_->discoverySamples() == 0,
+                         "discovery ran without the per-video opt-in"))
+                return;
+            reader_->setDiscovering(true);
+        }
         switch (phase_) {
             case Phase::Startup:
                 if (!store_.ready() || !loaded(source_) || !player_->ready())

--- a/src/app/PreferencesImageTelemetryPage.qml
+++ b/src/app/PreferencesImageTelemetryPage.qml
@@ -56,14 +56,14 @@ ScrollView {
 
             checked: Store.imageTelemetryEnabled
             objectName: "imageTelemetryEnabledPreference"
-            text: "Discover gauges while playing (confirm before extraction)"
+            text: "Allow image telemetry (gauge discovery and reading)"
 
             onToggled: Store.imageTelemetryEnabled = extractionToggle.checked
         }
         Label {
             Layout.fillWidth: true
             color: Style.mutedTextColor
-            text: "Discovery and reading run locally. The packaged reader (~2.2 MB) works offline. Turning discovery on never starts extraction: review the source-frame boxes, confirm the setup, then Start extraction. Native telemetry remains authoritative."
+            text: "Discovery and reading run locally. The packaged reader (~2.2 MB) works offline. Nothing runs by itself: choose Discover gauges on a video to scan it, review the source-frame boxes, confirm the setup, then Start extraction. Native telemetry remains authoritative."
             wrapMode: Text.Wrap
         }
         Rectangle {

--- a/tests/GaugeSetupTest.cpp
+++ b/tests/GaugeSetupTest.cpp
@@ -133,6 +133,10 @@ private slots:
         for (const auto& r : e.setup.regions) {
             QCOMPARE(r.hits, 3);
             QCOMPARE(r.enabled, !r.profileKey.isEmpty());
+            // The learned duplicate of a reviewed anchor keeps voting but is
+            // never shown on top of it.
+            QCOMPARE(r.suppressed, r.profileKey.isEmpty());
+            QCOMPARE(r.visible(), !r.profileKey.isEmpty());
         }
         // Same pixels in the learned inventory cannot consume profile evidence.
         auto& gear = e.setup.regions[4];
@@ -176,6 +180,128 @@ private slots:
         QCOMPARE(e.setup.regions[0].hits, 0);
         QCOMPARE(e.setup.regions[1].hits, 2);
         QVERIFY(!e.setup.regions[1].enabled);
+    }
+    static GaugeRegion learned(const QRectF& box,
+                               const char* semantic = "unknown",
+                               const char* representation = "digits") {
+        GaugeRegion r;
+        r.box = box;
+        r.semantic = semantic;
+        r.representation = representation;
+        r.detectorIdentity = "tiny-v2:hash";
+        r.enabled = false;
+        r.score = .9;
+        return r;
+    }
+    static int visibleCount(const GaugeSetup& setup) {
+        return std::count_if(setup.regions.cbegin(), setup.regions.cend(),
+                             [](const auto& r) { return r.visible(); });
+    }
+    void candidatesNeedASecondIndependentVote() {
+        GaugeEvidence e;
+        e.setup.detectorIdentity = "experimental-route-v1";
+        const auto glyph = learned({.2, .2, .05, .05});
+        QVERIFY(e.observe(0, {1920, 1080}, {glyph}));
+        QCOMPARE(e.setup.regions.size(), 1);
+        QCOMPARE(e.setup.regions[0].hits, 1);
+        QVERIFY(!e.setup.regions[0].visible());  // one frame is a candidate
+        // A repeated paused frame is not a vote.
+        QVERIFY(!e.observe(1'000'000'000, {1920, 1080}, {glyph}));
+        QVERIFY(!e.setup.regions[0].visible());
+        QVERIFY(e.observe(3'000'000'000, {1920, 1080}, {glyph}));
+        QCOMPARE(e.setup.regions[0].hits, GaugeSetup::VotesToShow);
+        QVERIFY(e.setup.regions[0].visible());
+        // A frame without it takes a vote back and hides it again.
+        QVERIFY(e.observe(6'000'000'000, {1920, 1080}, {}));
+        QCOMPARE(e.setup.regions[0].hits, 1);
+        QVERIFY(!e.setup.regions[0].visible());
+        // A different phantom every frame never accumulates anything shown.
+        for (int i = 3; i < 8; ++i)
+            QVERIFY(e.observe(i * 3'000'000'000LL, {1920, 1080},
+                              {learned({.1 * i, .5, .03, .03})}));
+        QCOMPARE(visibleCount(e.setup), 0);
+    }
+    void largerGaugeOutvotesNestedGlyphs() {
+        GaugeEvidence e;
+        e.setup.detectorIdentity = "experimental-route-v1";
+        const auto dial = learned({.2, .2, .2, .2}, "rpm", "needle");
+        const QVector<GaugeRegion> glyphs{
+            learned({.22, .22, .03, .03}), learned({.30, .22, .03, .03}),
+            learned({.22, .34, .03, .03}), learned({.30, .34, .03, .03})};
+        // The small glyphs are seen on more frames than the dial...
+        QVERIFY(e.observe(0, {1920, 1080}, glyphs));
+        QVERIFY(e.observe(3'000'000'000, {1920, 1080}, glyphs));
+        QCOMPARE(visibleCount(e.setup), 4);
+        QVERIFY(e.observe(6'000'000'000, {1920, 1080},
+                          glyphs + QVector<GaugeRegion>{dial}));
+        QCOMPARE(visibleCount(e.setup), 4);  // dial is still a candidate
+        QVERIFY(e.observe(9'000'000'000, {1920, 1080},
+                          glyphs + QVector<GaugeRegion>{dial}));
+        // ...but two votes for a box sixteen times their area outweigh four.
+        QCOMPARE(e.setup.regions.size(), 5);
+        QCOMPARE(visibleCount(e.setup), 1);
+        const auto& winner = e.setup.regions[4];
+        QCOMPARE(winner.representation, QString("needle"));
+        QVERIFY(winner.visible());
+        for (int i = 0; i < 4; ++i) {
+            QVERIFY(e.setup.regions[i].suppressed);
+            QCOMPARE(e.setup.regions[i].hits, 4);  // still voting
+        }
+        // When the dial stops appearing its votes decay and the glyphs return.
+        QVERIFY(e.observe(12'000'000'000, {1920, 1080}, glyphs));
+        QVERIFY(e.observe(15'000'000'000, {1920, 1080}, glyphs));
+        QCOMPARE(e.setup.regions[4].hits, 0);
+        QCOMPARE(visibleCount(e.setup), 4);
+        QVERIFY(e.observe(18'000'000'000, {1920, 1080}, glyphs));
+        QCOMPARE(e.setup.regions.size(), 4);  // retired after three misses
+        // Two boxes that merely touch are not a conflict.
+        const auto neighbour =
+            learned({.25, .22, .03, .03});  // right of glyph 0
+        QVERIFY(e.observe(21'000'000'000, {1920, 1080},
+                          glyphs + QVector<GaugeRegion>{neighbour}));
+        QVERIFY(e.observe(24'000'000'000, {1920, 1080},
+                          glyphs + QVector<GaugeRegion>{neighbour}));
+        QCOMPARE(visibleCount(e.setup), 5);
+    }
+    void oneFrameScreenBoxCannotHideEstablishedGauge() {
+        GaugeEvidence e;
+        e.setup.detectorIdentity = "experimental-route-v1";
+        const auto gauge = learned({.4, .8, .05, .05});
+        for (int i = 0; i < 5; ++i)
+            QVERIFY(e.observe(i * 3'000'000'000LL, {1920, 1080}, {gauge}));
+        QVERIFY(e.observe(
+            15'000'000'000, {1920, 1080},
+            {gauge, learned({.05, .05, .9, .9}, "unknown", "needle")}));
+        QCOMPARE(e.setup.regions.size(), 2);
+        QVERIFY(e.setup.regions[0].visible());
+        QVERIFY(!e.setup.regions[1].visible());
+        QVERIFY(!e.setup.regions[0].suppressed);
+    }
+    void userOwnedTracksAreNeverOutvoted() {
+        GaugeEvidence e;
+        e.setup.detectorIdentity = "experimental-route-v1";
+        const auto glyph = learned({.22, .22, .03, .03});
+        const auto dial = learned({.2, .2, .2, .2}, "rpm", "needle");
+        QVERIFY(e.observe(0, {1920, 1080}, {glyph}));
+        e.setup.regions[0].edited = true;  // the user moved/kept this box
+        e.setup.regions[0].enabled = true;
+        for (int i = 1; i < 5; ++i)
+            QVERIFY(
+                e.observe(i * 3'000'000'000LL, {1920, 1080}, {glyph, dial}));
+        QCOMPARE(e.setup.regions.size(), 2);
+        QVERIFY(e.setup.regions[0].visible());
+        QVERIFY(!e.setup.regions[0].suppressed);
+        QVERIFY(
+            e.setup.regions[1].suppressed);  // heavier, but nested on an edit
+        QCOMPARE(e.setup.regions[1].hits, 4);
+        // Saving keeps the evidence and drops the loser and any candidates.
+        QVERIFY(e.observe(15'000'000'000, {1920, 1080},
+                          {glyph, dial, learned({.7, .7, .05, .05})}));
+        QCOMPARE(e.setup.regions.size(), 3);
+        e.setup.pruneInvisible();
+        QCOMPARE(e.setup.regions.size(), 1);
+        QVERIFY(e.setup.regions[0].edited);
+        QVERIFY(e.setup.valid());
     }
     void profileCapacityIsReserved() {
         GaugeEvidence e;


### PR DESCRIPTION
## Problem
- Discovery started on every standalone video as soon as `video.image_telemetry` was on.
- Every single-frame detection immediately became a listed "gauge": phantom boxes, and small glyph boxes stacked inside the real gauge.

## Changes
- **Opt-in per video.** The preference only allows image telemetry. `ImageTelemetryController.discovering` is set by the overlay's *Discover gauges* toggle for the current video and cleared on every source change / reset. Nothing decodes or detects until then (saved proposals are not even loaded).
- **Ballot.** `GaugeEvidence::observe` treats every independent frame as a vote: +1 for re-detected tracks, −1 for the rest. Automatic learned tracks appear only after `VotesToShow` (2) votes, are confirmable after `VotesToConfirm` (3), and fade/retire when frames stop seeing them.
- **No overlaps.** `resolveOverlaps` admits anchored tracks (profile anchors, user edits, confirmations, persisted proposals) unconditionally, then automatic tracks heaviest first with weight `votes × √area`; conflicting (≥ half of the smaller box covered) losers are suppressed but keep voting. Sub-threshold candidates can't suppress anything, so a one-frame screen-sized box never hides an established gauge.
- Confirm setup prunes hidden/suppressed automatic tracks before saving.
- Both GL harnesses first assert that the enabled preference alone ran no discovery, then opt in per opened source like the overlay toggle.

## Verification
- `gauge-setup-test`: 16/16 including new ballot/overlap/prune cases.
- `lint-cpp-format`, `lint-qml*`, `image-telemetry-cache-test`, `apptypes-test` pass locally.
- GL discovery/scan harnesses not run here (no ORT/model bundle in this build); they were updated for the opt-in and should be run with the usual private fixtures.

Made with [Cursor](https://cursor.com)